### PR TITLE
Add environment-based audio engine selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Playback engine selection
+AUDIO_MODE=files          # files | realtime | auto
+REALTIME_ENABLED=false    # guards WebRTC flow even if selected
+NODE_ENV=development      # dev | staging | production
+
+# ElevenLabs (optional for files mode; mock if missing)
+ELEVENLABS_STREAMING=off
+ELEVENLABS_API_KEY=
+ELEVENLABS_VOICE_ID=placeholder_voice
+ELEVENLABS_MODEL=eleven_turbo_v2

--- a/apps/api/src/audio/flags.ts
+++ b/apps/api/src/audio/flags.ts
@@ -1,0 +1,18 @@
+export type AudioMode = "files" | "realtime" | "auto";
+
+export function getAudioMode(): AudioMode {
+  const m = (process.env.AUDIO_MODE || "auto").toLowerCase();
+  return (["files", "realtime", "auto"] as const).includes(m as AudioMode)
+    ? (m as AudioMode)
+    : "auto";
+}
+
+export function realtimeEnabled(): boolean {
+  return String(process.env.REALTIME_ENABLED || "false").toLowerCase() === "true";
+}
+
+export function isProdLike(): boolean {
+  const env = (process.env.NODE_ENV || "development").toLowerCase();
+  return env === "staging" || env === "production" || env === "prod";
+}
+

--- a/apps/api/src/audio/select.ts
+++ b/apps/api/src/audio/select.ts
@@ -1,0 +1,31 @@
+import { AudioEngine } from "./engine";
+import { ElevenLabsEngine } from "./engines/elevenlabs";
+import { OpenAIRealtimeEngine } from "./engines/openai-realtime";
+import { getAudioMode, realtimeEnabled, isProdLike } from "./flags";
+
+export type EngineChoice = "elevenlabs" | "openai-realtime";
+
+export function chooseEngine(params: {
+  mode: "run" | "replay" | "room-live";
+  storyVoicePolicy?: "premium" | "realtime-ok";
+}): EngineChoice {
+  const audioMode = getAudioMode();
+
+  // Hard overrides
+  if (audioMode === "files") return "elevenlabs";
+  if (audioMode === "realtime") return "openai-realtime";
+
+  if (params.storyVoicePolicy === "premium") {
+    return "elevenlabs";
+  }
+
+  // AUTO mode: dev uses files; prod/staging uses realtime for rooms if enabled
+  if (params.mode === "room-live" && isProdLike() && realtimeEnabled()) {
+    return "openai-realtime";
+  }
+  return "elevenlabs";
+}
+
+export function getEngine(choice: EngineChoice): AudioEngine {
+  return choice === "openai-realtime" ? new OpenAIRealtimeEngine() : new ElevenLabsEngine();
+}


### PR DESCRIPTION
## Summary
- add env example documenting audio playback flags
- centralize audio mode flags and helper utilities
- route audio engine selection through centralized flag helpers for auto mode

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3065522c88324ba6536702e9790da