### PR TITLE
Fix duplicated audio selection logic

### DIFF
--- a/apps/api/src/audio/flags.ts
+++ b/apps/api/src/audio/flags.ts
@@ -2,7 +2,6 @@ export type AudioMode = "files" | "realtime" | "auto";
 
 export function getAudioMode(): AudioMode {
   const m = (process.env.AUDIO_MODE || "auto").toLowerCase();
-  return ("files" === m || "realtime" === m || "auto" === m) ? (m as AudioMode) : "auto";
   return (["files", "realtime", "auto"] as const).includes(m as AudioMode)
     ? (m as AudioMode)
     : "auto";

--- a/apps/api/src/audio/select.ts
+++ b/apps/api/src/audio/select.ts
@@ -1,6 +1,7 @@
 import type { AudioEngine } from './engine';
 import { ElevenLabsEngine } from './engines/elevenlabs';
 import { OpenAIRealtimeEngine } from './engines/openai-realtime';
+import { getAudioMode, realtimeEnabled, isProdLike } from './flags';
 
 // Simple policy switch: per story, per mode
 export type EngineChoice = 'elevenlabs' | 'openai-realtime';
@@ -9,42 +10,23 @@ export function chooseEngine(params: {
   mode: 'run' | 'replay' | 'room-live';
   storyVoicePolicy?: 'premium' | 'realtime-ok';
 }): EngineChoice {
-  if (params.mode === 'room-live') return 'openai-realtime';
-  if (params.storyVoicePolicy === 'premium') return 'elevenlabs';
-  return 'elevenlabs'; // default for Runs/Replays
-}
-
-export function getEngine(choice: EngineChoice): AudioEngine {
-  if (choice === 'openai-realtime') return new OpenAIRealtimeEngine();
-  return new ElevenLabsEngine(); // default
-import { AudioEngine } from "./engine";
-import { ElevenLabsEngine } from "./engines/elevenlabs";
-import { OpenAIRealtimeEngine } from "./engines/openai-realtime";
-import { getAudioMode, realtimeEnabled, isProdLike } from "./flags";
-
-export type EngineChoice = "elevenlabs" | "openai-realtime";
-
-export function chooseEngine(params: {
-  mode: "run" | "replay" | "room-live";
-  storyVoicePolicy?: "premium" | "realtime-ok";
-}): EngineChoice {
   const audioMode = getAudioMode();
 
   // Hard overrides
-  if (audioMode === "files") return "elevenlabs";
-  if (audioMode === "realtime") return "openai-realtime";
+  if (audioMode === 'files') return 'elevenlabs';
+  if (audioMode === 'realtime') return 'openai-realtime';
 
-  if (params.storyVoicePolicy === "premium") {
-    return "elevenlabs";
+  if (params.storyVoicePolicy === 'premium') {
+    return 'elevenlabs';
   }
 
   // AUTO mode: dev uses files; prod/staging uses realtime for rooms if enabled
-  if (params.mode === "room-live" && isProdLike() && realtimeEnabled()) {
-    return "openai-realtime";
+  if (params.mode === 'room-live' && isProdLike() && realtimeEnabled()) {
+    return 'openai-realtime';
   }
-  return "elevenlabs";
+  return 'elevenlabs';
 }
 
 export function getEngine(choice: EngineChoice): AudioEngine {
-  return choice === "openai-realtime" ? new OpenAIRealtimeEngine() : new ElevenLabsEngine();
+  return choice === 'openai-realtime' ? new OpenAIRealtimeEngine() : new ElevenLabsEngine();
 }


### PR DESCRIPTION
## Summary
- remove the duplicated audio mode utility implementation
- consolidate audio engine selection logic to a single implementation that respects audio mode flags

## Testing
- pnpm lint *(fails: turbo not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3175dba208324b253e72197403d9c