### PR TITLE
Add Next.js operator console for Ovida

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:54322/postgres
 PORT=4000
 API_ORIGIN=http://localhost:4000
 APP_ORIGIN=http://localhost:8081
+NEXT_PUBLIC_API_ORIGIN=http://localhost:4000
+NEXT_PUBLIC_WS_ORIGIN=ws://localhost:4001/ws
 
 # Auth (handled by Supabase dashboard)
 GOOGLE_CLIENT_ID=replace_me

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository ships with a reusable GitHub Actions workflow that bundles the p
 - **apps/api** – Fastify OpenAPI-first service backed by Supabase Postgres and Auth
 - **apps/ws** – WebSocket coordinator for live rooms and voting atop Supabase Realtime
 - **apps/app** – Expo client (web + native) that drives demo, playback, and rooms
+- **apps/web** – Next.js operator console for demos, replays, rooms, and admin tooling
 - **packages/schemas** – Shared zod models for beats, replays, and policy definitions
 - **packages/sdk** – Typed SDK generated from the OpenAPI contract
 - **supabase/** – SQL migrations, seeds, and RLS policies for core data structures
@@ -88,7 +89,9 @@ You can test SFTP credentials locally with `lftp` or a similar client:
 make dev
 ```
 
-4. Launch the Expo app (`pnpm --filter @ovida/app dev`) and explore the 3-step demo.
+4. Launch the web console (`pnpm --filter @ovida/web dev`) to explore the demo, player, room, replay, and admin surfaces in the browser.
+
+5. Launch the Expo app (`pnpm --filter @ovida/app dev`) and explore the 3-step demo.
 
 See `.env.example` for required environment variables.
 After connecting, change to the configured remote directory and confirm that you have write permissions.

--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['next/core-web-vitals']
+};

--- a/apps/web/app/admin/page.module.css
+++ b/apps/web/app/admin/page.module.css
@@ -1,0 +1,337 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 32px;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 24px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.panel header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.panel header span {
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 13px;
+}
+
+.metrics {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 20px;
+}
+
+.metrics article {
+  background: rgba(56, 189, 248, 0.08);
+  padding: 24px;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.metrics article p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.metrics article strong {
+  font-size: 28px;
+}
+
+.metrics article span {
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.activityList {
+  display: grid;
+  gap: 16px;
+}
+
+.activityList article {
+  display: grid;
+  grid-template-columns: 12px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.activityList article span {
+  display: block;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  margin-top: 4px;
+}
+
+.activityList article p {
+  margin: 0 0 4px;
+  font-weight: 600;
+}
+
+.activityList article time {
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.storyList {
+  display: grid;
+  gap: 24px;
+}
+
+.storyList article {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.storyList ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.storyList li {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.storyHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.storyHeader h3 {
+  margin: 0;
+}
+
+.storyMeta {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tagList span {
+  background: rgba(148, 163, 184, 0.15);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.sceneBadge {
+  background: rgba(56, 189, 248, 0.15);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  margin-right: 8px;
+  display: inline-block;
+}
+
+.sceneBadge[data-status='draft'] {
+  background: rgba(248, 113, 113, 0.15);
+}
+
+.sceneBadge[data-status='ready'] {
+  background: rgba(251, 191, 36, 0.15);
+}
+
+.published {
+  color: #4ade80;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.draft {
+  color: #fbbf24;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 12px 0;
+}
+
+.table tbody tr + tr {
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.voiceList {
+  display: grid;
+  gap: 16px;
+}
+
+.voiceList article {
+  background: rgba(56, 189, 248, 0.08);
+  padding: 16px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.toggle input {
+  width: 18px;
+  height: 18px;
+}
+
+.radioGroup {
+  display: flex;
+  gap: 12px;
+}
+
+.radioGroup label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.radioLabel {
+  text-transform: capitalize;
+}
+
+.controlSummary {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.policyList {
+  display: grid;
+  gap: 16px;
+}
+
+.policyList article {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  padding: 20px;
+  display: grid;
+  gap: 8px;
+}
+
+.policyList article div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.reportList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.reportList li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.badge {
+  background: rgba(56, 189, 248, 0.2);
+  padding: 4px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.reportMeta {
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.analytics {
+  display: grid;
+  gap: 16px;
+}
+
+.analytics article {
+  background: rgba(56, 189, 248, 0.08);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.analytics article header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.analytics article span[data-trend='up'] {
+  color: #4ade80;
+}
+
+.analytics article span[data-trend='down'] {
+  color: #f87171;
+}
+
+.analytics article span[data-trend='flat'] {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 960px) {
+  .panel {
+    padding: 24px;
+  }
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,496 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import styles from './page.module.css';
+
+type MetricCard = {
+  id: string;
+  label: string;
+  value: string;
+  description?: string;
+};
+
+type ActivityItem = {
+  id: string;
+  time: string;
+  message: string;
+  type: 'run' | 'flag' | 'report';
+};
+
+type StoryGuide = {
+  id: string;
+  type: 'Character' | 'World' | 'Style';
+  title: string;
+  summary: string;
+};
+
+type StoryScene = {
+  id: string;
+  title: string;
+  premise: string;
+  status: 'draft' | 'ready' | 'published';
+};
+
+type StoryChapter = {
+  id: string;
+  title: string;
+  synopsis: string;
+  order: number;
+  scenes: StoryScene[];
+};
+
+type StoryItem = {
+  id: string;
+  title: string;
+  owner: string;
+  status: 'draft' | 'published';
+  updatedAt: string;
+  guides: StoryGuide[];
+  chapters: StoryChapter[];
+};
+
+type RoomItem = {
+  id: string;
+  story: string;
+  mode: 'duo' | 'party' | 'global';
+  status: 'vote_open' | 'playing' | 'paused';
+  members: number;
+  voteWindowMs: number;
+};
+
+type VoiceItem = {
+  id: string;
+  provider: string;
+  voiceId: string;
+  license: string;
+  defaultForStory?: string;
+};
+
+type PolicyVersion = {
+  id: string;
+  rating: string;
+  disallowed: string[];
+  softFilters: string[];
+  updatedAt: string;
+};
+
+type ReportItem = {
+  id: string;
+  target: string;
+  reason: string;
+  status: 'open' | 'reviewing' | 'closed';
+  submittedBy: string;
+};
+
+type AnalyticsMetric = {
+  id: string;
+  title: string;
+  description: string;
+  value: string;
+  trend: 'up' | 'down' | 'flat';
+};
+
+const dashboardMetrics: MetricCard[] = [
+  { id: 'rooms', label: 'Active Rooms', value: '12', description: 'Live rooms in the last hour' },
+  { id: 'participation', label: 'Vote Participation', value: '78%', description: 'Last 24 hours' },
+  { id: 'cache', label: 'TTS Cache Hit', value: '91%', description: 'Rolling 24 hour window' },
+  { id: 'latency', label: 'Choice → Audio Latency', value: '1.6s', description: 'P95 across all rooms' },
+  { id: 'policy', label: 'Policy Flags', value: '3', description: 'Awaiting moderator review' },
+];
+
+const activityFeed: ActivityItem[] = [
+  {
+    id: '1',
+    time: '2m ago',
+    message: 'Run #R-4213 verified checksum and published to canon v4.',
+    type: 'run',
+  },
+  {
+    id: '2',
+    time: '10m ago',
+    message: 'Flagged beat on Haunted Shore — profanity masked by policy v2.',
+    type: 'flag',
+  },
+  {
+    id: '3',
+    time: '18m ago',
+    message: 'User report opened for Room #RM-317: “Off-topic roleplay”.',
+    type: 'report',
+  },
+];
+
+const stories: StoryItem[] = [
+  {
+    id: 'story-1',
+    title: 'Haunted Shore',
+    owner: 'Jess (Producer)',
+    status: 'published',
+    updatedAt: 'Updated 1 hour ago',
+    guides: [
+      {
+        id: 'guide-1',
+        type: 'Character',
+        title: 'Captain Edda',
+        summary: 'Gruff salvager with secrets; voice gravelly but kind-hearted.',
+      },
+      {
+        id: 'guide-2',
+        type: 'World',
+        title: 'Mistbound Coast',
+        summary: 'Fog conceals phantasms; technology stalled at steam-and-salt.',
+      },
+      {
+        id: 'guide-3',
+        type: 'Style',
+        title: 'PG-13 Slow Burn',
+        summary: 'Lean pacing, suppressed gore, long-form tension.',
+      },
+    ],
+    chapters: [
+      {
+        id: 'chapter-1',
+        title: 'Arrival at Low Tide',
+        synopsis: 'The crew reaches the abandoned docks and senses echoes.',
+        order: 1,
+        scenes: [
+          {
+            id: 'scene-1',
+            title: 'Boarding the Wreck',
+            premise: 'Explore the shipwreck and uncover the first haunt.',
+            status: 'published',
+          },
+          {
+            id: 'scene-2',
+            title: 'Echoes in the Hold',
+            premise: 'Players negotiate with the lingering spirits.',
+            status: 'ready',
+          },
+        ],
+      },
+      {
+        id: 'chapter-2',
+        title: 'Signals in the Storm',
+        synopsis: 'A beacon lures the crew deeper into the fog.',
+        order: 2,
+        scenes: [
+          {
+            id: 'scene-3',
+            title: 'The Broken Beacon',
+            premise: 'Repairing the beacon reveals a paradox.',
+            status: 'draft',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'story-2',
+    title: 'Chronomancer Uprising',
+    owner: 'Liam (Producer)',
+    status: 'draft',
+    updatedAt: 'Updated yesterday',
+    guides: [
+      {
+        id: 'guide-4',
+        type: 'Character',
+        title: 'Archivist Nyla',
+        summary: 'Time-locked archivist who trades memories for favors.',
+      },
+    ],
+    chapters: [
+      {
+        id: 'chapter-3',
+        title: 'Clockwork Citadel',
+        synopsis: 'Rebel chronomancers seize the capital tower.',
+        order: 1,
+        scenes: [
+          {
+            id: 'scene-4',
+            title: 'Breach the Vault',
+            premise: 'Players bend temporal locks to reach the archives.',
+            status: 'draft',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const rooms: RoomItem[] = [
+  { id: 'RM-317', story: 'Haunted Shore', mode: 'party', status: 'vote_open', members: 48, voteWindowMs: 12000 },
+  { id: 'RM-992', story: 'Chronomancer Uprising', mode: 'global', status: 'playing', members: 212, voteWindowMs: 8000 },
+  { id: 'RM-101', story: 'Haunted Shore', mode: 'duo', status: 'paused', members: 2, voteWindowMs: 15000 },
+];
+
+const voices: VoiceItem[] = [
+  { id: 'voice-1', provider: 'ElevenLabs', voiceId: 'MistWarden', license: 'Streaming + Replay', defaultForStory: 'Haunted Shore' },
+  { id: 'voice-2', provider: 'PlayHT', voiceId: 'ChronoAdept', license: 'Streaming only' },
+  { id: 'voice-3', provider: 'MetaVoice', voiceId: 'Oracle-Δ', license: 'Streaming + Commercial' },
+];
+
+const policies: PolicyVersion[] = [
+  {
+    id: 'policy-4',
+    rating: 'T for Teen',
+    disallowed: ['Explicit violence', 'Sexual content', 'Slurs'],
+    softFilters: ['Body horror', 'Existential dread'],
+    updatedAt: 'Updated 4 hours ago',
+  },
+  {
+    id: 'policy-3',
+    rating: 'PG-13',
+    disallowed: ['Explicit violence', 'Strong profanity'],
+    softFilters: ['Religious themes'],
+    updatedAt: 'Updated 2 days ago',
+  },
+];
+
+const reports: ReportItem[] = [
+  { id: 'RP-8892', target: 'Room RM-317', reason: 'Off-topic roleplay', status: 'reviewing', submittedBy: 'guest-189' },
+  { id: 'RP-8893', target: 'Run R-4123', reason: 'Lore inconsistency', status: 'open', submittedBy: 'producer-kai' },
+];
+
+const analytics: AnalyticsMetric[] = [
+  { id: 'metric-1', title: 'Average Beat Rating', description: 'Guest thumbs-up / thumbs-down ratio (24h).', value: '4.6 / 5', trend: 'up' },
+  { id: 'metric-2', title: 'Policy Interventions', description: 'Auto-moderated beats this week.', value: '17', trend: 'flat' },
+  { id: 'metric-3', title: 'Audio Render Latency', description: 'Median seconds from vote close to playback.', value: '1.8s', trend: 'down' },
+];
+
+const statusColors: Record<ActivityItem['type'], string> = {
+  run: '#4ade80',
+  flag: '#f97316',
+  report: '#f87171',
+};
+
+export default function AdminPage() {
+  const [autoModeration, setAutoModeration] = useState(true);
+  const [safetyMode, setSafetyMode] = useState<'relaxed' | 'standard' | 'strict'>('standard');
+
+  const safetyDescription = useMemo(() => {
+    switch (safetyMode) {
+      case 'relaxed':
+        return 'Minimal filtering, best for internal QA rooms.';
+      case 'strict':
+        return 'Aggressive guardrails, muted speculative content.';
+      default:
+        return 'Balanced guardrails tuned for public showcase rooms.';
+    }
+  }, [safetyMode]);
+
+  return (
+    <div className={styles.grid}>
+      <section className={styles.metrics}>
+        {dashboardMetrics.map((metric) => (
+          <article key={metric.id}>
+            <p>{metric.label}</p>
+            <strong>{metric.value}</strong>
+            {metric.description && <span>{metric.description}</span>}
+          </article>
+        ))}
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Realtime Activity</h2>
+          <span>Last 30 minutes</span>
+        </header>
+        <div className={styles.activityList}>
+          {activityFeed.map((item) => (
+            <article key={item.id}>
+              <span style={{ background: statusColors[item.type] }} />
+              <div>
+                <p>{item.message}</p>
+                <time>{item.time}</time>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Story Library</h2>
+          <span>Guides, chapters, and scenes</span>
+        </header>
+        <div className={styles.storyList}>
+          {stories.map((story) => (
+            <article key={story.id}>
+              <div className={styles.storyHeader}>
+                <h3>{story.title}</h3>
+                <span className={story.status === 'published' ? styles.published : styles.draft}>
+                  {story.status}
+                </span>
+              </div>
+              <p className={styles.storyMeta}>
+                {story.owner} • {story.updatedAt}
+              </p>
+              <div className={styles.tagList}>
+                {story.guides.map((guide) => (
+                  <span key={guide.id}>{guide.type}: {guide.title}</span>
+                ))}
+              </div>
+              <ul>
+                {story.chapters.map((chapter) => (
+                  <li key={chapter.id}>
+                    <div>
+                      <strong>Chapter {chapter.order}: {chapter.title}</strong>
+                      <p>{chapter.synopsis}</p>
+                    </div>
+                    <div>
+                      {chapter.scenes.map((scene) => (
+                        <span key={scene.id} className={styles.sceneBadge} data-status={scene.status}>
+                          {scene.title}
+                        </span>
+                      ))}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Room Monitor</h2>
+          <span>Vote windows &amp; status</span>
+        </header>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Room</th>
+              <th>Story</th>
+              <th>Mode</th>
+              <th>Status</th>
+              <th>Members</th>
+              <th>Vote Window</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rooms.map((room) => (
+              <tr key={room.id}>
+                <td>{room.id}</td>
+                <td>{room.story}</td>
+                <td>{room.mode}</td>
+                <td>{room.status.replace('_', ' ')}</td>
+                <td>{room.members}</td>
+                <td>{Math.round(room.voteWindowMs / 1000)}s</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Voice Library</h2>
+          <span>Streaming entitlements</span>
+        </header>
+        <div className={styles.voiceList}>
+          {voices.map((voice) => (
+            <article key={voice.id}>
+              <h3>{voice.voiceId}</h3>
+              <p>{voice.provider} • {voice.license}</p>
+              {voice.defaultForStory && <span>Default for {voice.defaultForStory}</span>}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Safety Controls</h2>
+          <span>Fine-tune content guardrails</span>
+        </header>
+        <div className={styles.controls}>
+          <label className={styles.toggle}>
+            <input
+              type="checkbox"
+              checked={autoModeration}
+              onChange={(event) => setAutoModeration(event.target.checked)}
+            />
+            <span>Auto-moderate policy violations</span>
+          </label>
+          <div className={styles.radioGroup}>
+            {(['relaxed', 'standard', 'strict'] as const).map((level) => (
+              <label key={level}>
+                <input
+                  type="radio"
+                  name="safety-mode"
+                  checked={safetyMode === level}
+                  onChange={() => setSafetyMode(level)}
+                />
+                <span className={styles.radioLabel}>{level}</span>
+              </label>
+            ))}
+          </div>
+          <p className={styles.controlSummary}>{safetyDescription}</p>
+        </div>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Policy Versions</h2>
+          <span>Content filters &amp; updates</span>
+        </header>
+        <div className={styles.policyList}>
+          {policies.map((policy) => (
+            <article key={policy.id}>
+              <h3>{policy.rating}</h3>
+              <p>{policy.updatedAt}</p>
+              <div>
+                <strong>Disallowed</strong>
+                <span>{policy.disallowed.join(', ')}</span>
+              </div>
+              <div>
+                <strong>Soft filters</strong>
+                <span>{policy.softFilters.join(', ')}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Reports</h2>
+          <span>Flagged runs &amp; rooms</span>
+        </header>
+        <ul className={styles.reportList}>
+          {reports.map((report) => (
+            <li key={report.id}>
+              <div>
+                <strong>{report.target}</strong>
+                <span>{report.reason}</span>
+              </div>
+              <div>
+                <span className={styles.badge}>{report.status}</span>
+                <span className={styles.reportMeta}>by {report.submittedBy}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.panel}>
+        <header>
+          <h2>Analytics</h2>
+          <span>Quality and operations</span>
+        </header>
+        <div className={styles.analytics}>
+          {analytics.map((metric) => (
+            <article key={metric.id}>
+              <header>
+                <h3>{metric.title}</h3>
+                <span data-trend={metric.trend}>{metric.trend}</span>
+              </header>
+              <p>{metric.value}</p>
+              <small>{metric.description}</small>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,32 @@
+:root {
+  color-scheme: light dark;
+  --background: #0f172a;
+  --foreground: #f8fafc;
+  --panel: rgba(15, 23, 42, 0.75);
+  --accent: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #020617 0%, #0f172a 50%, #1e293b 100%);
+  color: var(--foreground);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}
+
+main {
+  width: 100%;
+}

--- a/apps/web/app/layout.module.css
+++ b/apps/web/app/layout.module.css
@@ -1,0 +1,65 @@
+.shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  backdrop-filter: blur(24px);
+}
+
+.sidebar {
+  padding: 32px 24px;
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.title {
+  margin: 0 0 24px;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 16px;
+}
+
+.nav a {
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: background 0.2s ease;
+}
+
+.nav a:hover,
+.nav a:focus-visible {
+  background: rgba(56, 189, 248, 0.2);
+}
+
+.main {
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+@media (max-width: 960px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,32 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import styles from './layout.module.css';
+
+export const metadata: Metadata = {
+  title: 'Ovida Console',
+  description: 'Control demos, review replays, and monitor live rooms.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <div className={styles.shell}>
+          <aside className={styles.sidebar}>
+            <h1 className={styles.title}>Ovida</h1>
+            <nav className={styles.nav}>
+              <Link href="/">Demo</Link>
+              <Link href="/player/demo">Player</Link>
+              <Link href="/replay/demo">Replay</Link>
+              <Link href="/room/demo">Room</Link>
+              <Link href="/admin">Admin</Link>
+            </nav>
+          </aside>
+          <main className={styles.main}>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/page.module.css
+++ b/apps/web/app/page.module.css
@@ -1,0 +1,99 @@
+.hero {
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 32px 64px rgba(2, 6, 23, 0.55);
+  max-width: 720px;
+}
+
+.eyebrow {
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+  margin-bottom: 12px;
+}
+
+.summary {
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.actions {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.actions button {
+  padding: 12px 20px;
+  background: var(--accent);
+  color: #04121f;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+  box-shadow: none;
+}
+
+.actions button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px rgba(56, 189, 248, 0.35);
+}
+
+.primaryLink {
+  padding: 12px 20px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.primaryLink:hover {
+  background: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.7);
+}
+
+.error {
+  color: #fca5a5;
+  font-weight: 600;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.footer a {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 32px 24px;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primaryLink,
+  .actions button {
+    text-align: center;
+  }
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { apiFetch } from '@/lib/api';
+import styles from './page.module.css';
+
+type DemoResponse = {
+  guest_id: string;
+  run_id: string;
+  beat: { narration: string };
+};
+
+export default function HomePage() {
+  const [demo, setDemo] = useState<DemoResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleStartDemo = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await apiFetch<DemoResponse>('/v1/demos/start', { method: 'POST' });
+      setDemo(payload);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to start demo');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const summary = useMemo(() => {
+    if (!demo) {
+      return 'Start the 3-step Haunted Shore demo to receive a fresh narration and run identifier that you can explore across the player, room, and admin surfaces.';
+    }
+    return demo.beat.narration;
+  }, [demo]);
+
+  return (
+    <section className={styles.hero}>
+      <header>
+        <p className={styles.eyebrow}>Interactive Narrative Demo</p>
+        <h2>Shape the haunted shoreline together.</h2>
+      </header>
+      <p className={styles.summary}>{summary}</p>
+      <div className={styles.actions}>
+        <button onClick={handleStartDemo} disabled={loading}>
+          {loading ? 'Starting…' : 'Start Demo'}
+        </button>
+        {demo && (
+          <Link className={styles.primaryLink} href={`/player/${demo.run_id}`}>
+            Open Player
+          </Link>
+        )}
+      </div>
+      {error && <p className={styles.error}>{error}</p>}
+      <footer className={styles.footer}>
+        <span>Operator tools</span>
+        <Link href="/admin">Admin Console</Link>
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/app/player/[runId]/page.module.css
+++ b/apps/web/app/player/[runId]/page.module.css
@@ -1,0 +1,34 @@
+.player {
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 720px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+  margin-bottom: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.actions a {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  transition: background 0.2s ease;
+}
+
+.actions a:hover {
+  background: rgba(148, 163, 184, 0.2);
+}

--- a/apps/web/app/player/[runId]/page.tsx
+++ b/apps/web/app/player/[runId]/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import styles from './page.module.css';
+
+export default function PlayerPage({ params }: { params: { runId: string } }) {
+  const { runId } = params;
+
+  return (
+    <section className={styles.player}>
+      <header>
+        <p className={styles.eyebrow}>Player Controls</p>
+        <h2>Run {runId}</h2>
+      </header>
+      <p>
+        Launch a synchronized experience for viewers. From here you can jump into the live room to
+        vote or review a recorded replay of the story so far.
+      </p>
+      <div className={styles.actions}>
+        <Link href={`/replay/${runId}`}>View Replay</Link>
+        <Link href={`/room/${runId}`}>Enter Room</Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/replay/[runId]/page.module.css
+++ b/apps/web/app/replay/[runId]/page.module.css
@@ -1,0 +1,31 @@
+.replay {
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 860px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+  margin-bottom: 12px;
+}
+
+pre {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  padding: 24px;
+  overflow-x: auto;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.error {
+  color: #fca5a5;
+  font-weight: 600;
+}

--- a/apps/web/app/replay/[runId]/page.tsx
+++ b/apps/web/app/replay/[runId]/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/api';
+import styles from './page.module.css';
+
+type ReplayPayload = Record<string, unknown>;
+
+export default function ReplayPage({ params }: { params: { runId: string } }) {
+  const { runId } = params;
+  const [replay, setReplay] = useState<ReplayPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<ReplayPayload>(`/v1/runs/${runId}/replay`)
+      .then((data) => {
+        if (!cancelled) {
+          setReplay(data);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unable to load replay');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  return (
+    <section className={styles.replay}>
+      <header>
+        <p className={styles.eyebrow}>Replay</p>
+        <h2>Run {runId}</h2>
+      </header>
+      {error && <p className={styles.error}>{error}</p>}
+      <pre>{JSON.stringify(replay, null, 2)}</pre>
+    </section>
+  );
+}

--- a/apps/web/app/room/[runId]/page.module.css
+++ b/apps/web/app/room/[runId]/page.module.css
@@ -1,0 +1,66 @@
+.room {
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 860px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+  margin-bottom: 12px;
+}
+
+button {
+  width: fit-content;
+  padding: 12px 18px;
+  border-radius: 10px;
+  border: none;
+  background: var(--accent);
+  color: #04121f;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+header span {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.connected {
+  color: #4ade80;
+}
+
+.disconnected {
+  color: #f97316;
+}
+
+.log {
+  display: grid;
+  gap: 12px;
+}
+
+.log article {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 16px;
+  border-radius: 12px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 14px;
+  line-height: 1.5;
+}

--- a/apps/web/app/room/[runId]/page.tsx
+++ b/apps/web/app/room/[runId]/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { wsOrigin } from '@/lib/config';
+import styles from './page.module.css';
+
+type Message = {
+  id: string;
+  payload: string;
+};
+
+export default function RoomPage({ params }: { params: { runId: string } }) {
+  const { runId } = params;
+  const socketRef = useRef<WebSocket | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const socket = new WebSocket(wsOrigin);
+    socketRef.current = socket;
+
+    socket.onopen = () => setConnected(true);
+    socket.onclose = () => setConnected(false);
+    socket.onerror = () => setConnected(false);
+    socket.onmessage = (event) => {
+      const data = typeof event.data === 'string' ? event.data : event.data.toString();
+      setMessages((prev) => [
+        { id: `${Date.now()}-${prev.length}`, payload: data },
+        ...prev,
+      ]);
+    };
+
+    return () => {
+      socket.close();
+    };
+  }, []);
+
+  const sendVote = useCallback(() => {
+    const vote = {
+      type: 'room.vote',
+      roomId: runId,
+      choiceId: 'continue',
+      beatIdx: 0,
+    };
+    socketRef.current?.send(JSON.stringify(vote));
+  }, [runId]);
+
+  return (
+    <section className={styles.room}>
+      <header>
+        <p className={styles.eyebrow}>Live Room</p>
+        <h2>Run {runId}</h2>
+        <span className={connected ? styles.connected : styles.disconnected}>
+          {connected ? 'Connected' : 'Disconnected'}
+        </span>
+      </header>
+      <button onClick={sendVote} disabled={!connected}>
+        Cast Vote
+      </button>
+      <div className={styles.log}>
+        {messages.length === 0 && <p>No events yet. Votes and realtime updates appear here.</p>}
+        {messages.map((message) => (
+          <article key={message.id}>{message.payload}</article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,36 @@
+const apiOrigin = process.env.NEXT_PUBLIC_API_ORIGIN ?? 'http://localhost:4000';
+
+type ApiOptions = RequestInit & { skipJson?: boolean };
+
+export async function apiFetch<T>(path: string, init?: ApiOptions): Promise<T> {
+  const response = await fetch(`${apiOrigin}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const message = await safeReadError(response);
+    throw new Error(message);
+  }
+
+  if (init?.skipJson) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+async function safeReadError(res: Response) {
+  try {
+    const data = await res.json();
+    if (typeof data?.message === 'string') {
+      return data.message;
+    }
+  } catch (error) {
+    // ignore
+  }
+  return `Request failed with status ${res.status}`;
+}

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -1,0 +1,2 @@
+export const apiOrigin = process.env.NEXT_PUBLIC_API_ORIGIN ?? 'http://localhost:4000';
+export const wsOrigin = process.env.NEXT_PUBLIC_WS_ORIGIN ?? 'ws://localhost:4001/ws';

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ovida/web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.79",
+    "@types/react-dom": "18.2.25",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/lib/*": ["lib/*"],
+      "@/components/*": ["components/*"]
+    },
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js web console alongside the Expo client with demo, player, replay, room, and admin views
- share API and websocket configuration helpers for browser usage and document the new app in the README and env example

## Testing
- pnpm install *(fails: repository depends on unpublished fastify-zod/@fastify/helmet versions)*

------
https://chatgpt.com/codex/tasks/task_e_68e35f11033c83249e53926ed6a3474e