### PR TITLE
Configure static export for web app

### DIFF
--- a/apps/web/app/replay/[runId]/page.module.css
+++ b/apps/web/app/replay/[runId]/page.module.css
@@ -16,7 +16,7 @@
   margin-bottom: 12px;
 }
 
-pre {
+.log {
   background: rgba(15, 23, 42, 0.6);
   border-radius: 16px;
   padding: 24px;

--- a/apps/web/app/replay/[runId]/page.tsx
+++ b/apps/web/app/replay/[runId]/page.tsx
@@ -36,7 +36,7 @@ export default function ReplayPage({ params }: { params: { runId: string } }) {
         <h2>Run {runId}</h2>
       </header>
       {error && <p className={styles.error}>{error}</p>}
-      <pre>{JSON.stringify(replay, null, 2)}</pre>
+      <pre className={styles.log}>{JSON.stringify(replay, null, 2)}</pre>
     </section>
   );
 }

--- a/apps/web/app/room/[runId]/page.module.css
+++ b/apps/web/app/room/[runId]/page.module.css
@@ -16,7 +16,7 @@
   margin-bottom: 12px;
 }
 
-button {
+.voteButton {
   width: fit-content;
   padding: 12px 18px;
   border-radius: 10px;
@@ -27,18 +27,18 @@ button {
   cursor: pointer;
 }
 
-button:disabled {
+.voteButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-header {
+.header {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-header span {
+.header span {
   font-size: 13px;
   font-weight: 600;
 }

--- a/apps/web/app/room/[runId]/page.tsx
+++ b/apps/web/app/room/[runId]/page.tsx
@@ -47,14 +47,14 @@ export default function RoomPage({ params }: { params: { runId: string } }) {
 
   return (
     <section className={styles.room}>
-      <header>
+      <header className={styles.header}>
         <p className={styles.eyebrow}>Live Room</p>
         <h2>Run {runId}</h2>
         <span className={connected ? styles.connected : styles.disconnected}>
           {connected ? 'Connected' : 'Disconnected'}
         </span>
       </header>
-      <button onClick={sendVote} disabled={!connected}>
+      <button className={styles.voteButton} onClick={sendVote} disabled={!connected}>
         Cast Vote
       </button>
       <div className={styles.log}>

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'export',
+  images: {
+    unoptimized: true
+  },
   experimental: {
     typedRoutes: true
   }


### PR DESCRIPTION
## Summary
- enable static export for the web application and unoptimized Next.js images
- scope replay and room styles to module classes to satisfy CSS module purity rules

## Testing
- pnpm build --filter @ovida/web *(fails: turbo command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3669f4c208324be9c353fa87d597f