### PR TITLE
Fix build dependency constraints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,13 +14,13 @@
   "dependencies": {
     "@fastify/cookie": "^9.3.1",
     "@fastify/cors": "^9.0.1",
-    "@fastify/helmet": "^12.1.1",
+    "@fastify/helmet": "^13.0.2",
     "@fastify/sensible": "^5.0.1",
     "@ovida/schemas": "workspace:*",
     "@supabase/supabase-js": "^2.43.4",
     "dotenv": "^16.4.5",
     "fastify": "^4.26.2",
-    "fastify-zod": "^1.5.0",
+    "fastify-zod": "^1.4.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "^18.19.50",
     "openapi-typescript": "^7.3.1",
     "tsup": "^8.0.1",
     "typescript": "^5.4.5",


### PR DESCRIPTION
## Summary
- add the Node.js type definitions to the SDK package so its tsup DTS build can resolve the configured `node` types
- update Fastify-related dependencies in the API package to versions that are available in the public registry

## Testing
- pnpm install
- pnpm build *(fails: Next.js export mode requires `generateStaticParams` for /player/[runId])*

------
https://chatgpt.com/codex/tasks/task_e_68e367bb09b88324bd20a0df25fb816a