### PR TITLE
Add unit tests for audio core functions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "lint": "eslint 'src/**/*.ts'",
+    "test:unit": "vitest run --config vitest.config.ts",
     "test:e2e": "vitest run --config vitest.config.ts"
   },
   "dependencies": {

--- a/apps/api/src/audio/engine.spec.ts
+++ b/apps/api/src/audio/engine.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { audioCacheKey, type SynthesisOpts } from './engine';
+
+describe('audioCacheKey', () => {
+  it('builds a deterministic cache key using synthesis options and voice id', () => {
+    const opts: SynthesisOpts = {
+      storyId: 'story-1',
+      seed: 123,
+      beatIdx: 4,
+      modelVersion: 'model-v2',
+      policyVersion: 'policy-v3',
+      canonVersion: 'canon-v1',
+      voiceId: 'ignored-in-function',
+    };
+
+    expect(audioCacheKey(opts, 'voice-abc')).toBe('ovida:story-1:123:4:model-v2:policy-v3:canon-v1:voice-abc');
+  });
+
+  it('defaults the voice component when no voice id is provided', () => {
+    const opts: SynthesisOpts = {
+      storyId: 'story-2',
+      seed: 99,
+      beatIdx: 0,
+      modelVersion: 'model-v1',
+      policyVersion: 'policy-v1',
+      canonVersion: 'canon-v1',
+    };
+
+    expect(audioCacheKey(opts, undefined)).toBe('ovida:story-2:99:0:model-v1:policy-v1:canon-v1:default');
+  });
+});

--- a/apps/api/src/audio/flags.spec.ts
+++ b/apps/api/src/audio/flags.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { getAudioMode, realtimeEnabled, isProdLike } from './flags';
+
+type Env = NodeJS.ProcessEnv;
+
+const ORIGINAL_ENV: Env = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('getAudioMode', () => {
+  it('returns validated audio mode when explicitly set', () => {
+    process.env.AUDIO_MODE = 'files';
+    expect(getAudioMode()).toBe('files');
+
+    process.env.AUDIO_MODE = 'realtime';
+    expect(getAudioMode()).toBe('realtime');
+  });
+
+  it('falls back to auto when value is missing or invalid', () => {
+    delete process.env.AUDIO_MODE;
+    expect(getAudioMode()).toBe('auto');
+
+    process.env.AUDIO_MODE = 'unknown-mode';
+    expect(getAudioMode()).toBe('auto');
+  });
+});
+
+describe('realtimeEnabled', () => {
+  it('interprets truthy values case-insensitively', () => {
+    process.env.REALTIME_ENABLED = 'TrUe';
+    expect(realtimeEnabled()).toBe(true);
+  });
+
+  it('treats other values as false', () => {
+    process.env.REALTIME_ENABLED = 'nope';
+    expect(realtimeEnabled()).toBe(false);
+
+    delete process.env.REALTIME_ENABLED;
+    expect(realtimeEnabled()).toBe(false);
+  });
+});
+
+describe('isProdLike', () => {
+  it('returns true for production-like environments', () => {
+    process.env.NODE_ENV = 'Production';
+    expect(isProdLike()).toBe(true);
+
+    process.env.NODE_ENV = 'staging';
+    expect(isProdLike()).toBe(true);
+
+    process.env.NODE_ENV = 'prod';
+    expect(isProdLike()).toBe(true);
+  });
+
+  it('returns false for non-production environments', () => {
+    process.env.NODE_ENV = 'development';
+    expect(isProdLike()).toBe(false);
+
+    delete process.env.NODE_ENV;
+    expect(isProdLike()).toBe(false);
+  });
+});

--- a/apps/api/src/audio/select.spec.ts
+++ b/apps/api/src/audio/select.spec.ts
@@ -1,0 +1,54 @@
+import { beforeEach, afterAll, describe, expect, it } from 'vitest';
+import { chooseEngine, getEngine } from './select';
+import { ElevenLabsEngine } from './engines/elevenlabs';
+import { OpenAIRealtimeEngine } from './engines/openai-realtime';
+
+type Env = NodeJS.ProcessEnv;
+
+const ORIGINAL_ENV: Env = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('chooseEngine', () => {
+  it('prefers explicit audio mode overrides', () => {
+    process.env.AUDIO_MODE = 'files';
+    expect(chooseEngine({ mode: 'run' })).toBe('elevenlabs');
+
+    process.env.AUDIO_MODE = 'realtime';
+    expect(chooseEngine({ mode: 'run' })).toBe('openai-realtime');
+  });
+
+  it('returns elevenlabs when story policy requires premium voices', () => {
+    process.env.AUDIO_MODE = 'auto';
+    expect(chooseEngine({ mode: 'run', storyVoicePolicy: 'premium' })).toBe('elevenlabs');
+  });
+
+  it('enables realtime engine for live rooms in prod-like envs', () => {
+    process.env.AUDIO_MODE = 'auto';
+    process.env.NODE_ENV = 'production';
+    process.env.REALTIME_ENABLED = 'true';
+
+    expect(chooseEngine({ mode: 'room-live', storyVoicePolicy: 'realtime-ok' })).toBe('openai-realtime');
+  });
+
+  it('falls back to elevenlabs otherwise', () => {
+    process.env.AUDIO_MODE = 'auto';
+    process.env.NODE_ENV = 'development';
+    process.env.REALTIME_ENABLED = 'false';
+
+    expect(chooseEngine({ mode: 'room-live' })).toBe('elevenlabs');
+  });
+});
+
+describe('getEngine', () => {
+  it('instantiates the corresponding engine implementation', () => {
+    expect(getEngine('elevenlabs')).toBeInstanceOf(ElevenLabsEngine);
+    expect(getEngine('openai-realtime')).toBeInstanceOf(OpenAIRealtimeEngine);
+  });
+});

--- a/apps/api/src/audio/soundstage.spec.ts
+++ b/apps/api/src/audio/soundstage.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { planSoundstage } from './soundstage';
+import type { SynthesisOpts } from './engine';
+import * as crypto from 'node:crypto';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('planSoundstage', () => {
+  const baseOpts: SynthesisOpts = {
+    storyId: 'story-123',
+    seed: 42,
+    beatIdx: 2,
+    modelVersion: 'v1',
+    policyVersion: 'p1',
+    canonVersion: 'c1',
+  };
+
+  it('selects matching cues and ambience based on keywords', () => {
+    const uuidSequence = ['id-1', 'id-2'];
+    let call = 0;
+    vi.spyOn(crypto, 'randomUUID').mockImplementation(() => uuidSequence[call++] ?? 'fallback');
+
+    const result = planSoundstage('The storm thunder shakes the door while lightning flashes.', baseOpts);
+
+    expect(result.ambience?.id).toBe('noir-alley');
+    expect(result.cues).toHaveLength(2);
+    expect(result.cues[0]).toMatchObject({
+      id: 'id-1',
+      label: 'Crackling Thunderclap',
+      assetUrl: 'https://assets.ovida.fm/sfx/thunder-radio.ogg',
+      intensity: 'big',
+      startMs: 800,
+    });
+    expect(result.cues[1]).toMatchObject({
+      id: 'id-2',
+      label: 'Wooden Door Creak',
+      startMs: 520,
+    });
+    expect(result.inspiration).toEqual([
+      'Crackling Thunderclap',
+      'Wooden Door Creak',
+    ]);
+  });
+
+  it('falls back to default ambience and inspiration when no keywords match', () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('unused');
+
+    const result = planSoundstage('A calm narration with no special events.', {
+      ...baseOpts,
+      beatIdx: 0,
+    });
+
+    expect(result.ambience?.id).toBe('broadcast-hum');
+    expect(result.cues).toHaveLength(0);
+    expect(result.inspiration).toEqual(['Studio Narration', 'Magnetic Tape Warmth']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
-    "test": "turbo test"
+    "test": "turbo test",
+    "test:unit": "pnpm --filter @ovida/api test:unit"
   },
   "devDependencies": {
     "turbo": "^1.13.3"


### PR DESCRIPTION
## Summary
- add Vitest unit tests for the core audio helpers covering flags, engine selection, cache keys, and soundstage planning
- add dedicated unit test scripts for the API package and workspace-level runner to execute them on Linux servers

## Testing
- pnpm --filter @ovida/api test:unit *(fails: Vitest not installed because workspace dependencies are unavailable without resolving the @fastify/helmet version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68e3688edd7c8324bc0715d6e38c933a