### PR TITLE
feat: add OpenAI scene imagery generation

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -12,6 +12,8 @@ const EnvSchema = z.object({
   ELEVENLABS_STREAMING: z.enum(['on', 'off']).default('off'),
   API_ORIGIN: z.string().url().optional(),
   APP_ORIGIN: z.string().url().optional(),
+  OPENAI_API_KEY: z.string().min(1).optional(),
+  OPENAI_API_BASE_URL: z.string().url().optional(),
 });
 
 export type Env = z.infer<typeof EnvSchema>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { registerStoryRoutes } from './routes/stories';
 import { registerRunRoutes } from './routes/runs';
 import { registerReplayRoutes } from './routes/replays';
 import { registerRoomRoutes } from './routes/rooms.http';
+import { registerSceneImageRoutes } from './routes/scenes.images';
 
 const bootstrap = async () => {
   const env = loadEnv();
@@ -34,6 +35,7 @@ const bootstrap = async () => {
   await registerRunRoutes(app);
   await registerReplayRoutes(app);
   await registerRoomRoutes(app);
+  await registerSceneImageRoutes(app);
 
   try {
     await app.listen({ port: env.PORT, host: '0.0.0.0' });

--- a/apps/api/src/routes/scenes.images.ts
+++ b/apps/api/src/routes/scenes.images.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { generateSceneImages, SceneImageError } from '../services/images.openai';
+
+const SceneImageSchema = z.object({
+  scene_id: z.string().min(1),
+  scene_title: z.string().min(1),
+  path_id: z.string().min(1),
+  path_label: z.string().min(1),
+  path_summary: z.string().min(1),
+  prompt: z.string().min(1),
+  style: z.string().optional(),
+});
+
+export async function registerSceneImageRoutes(app: FastifyInstance) {
+  app.post('/v1/scenes/images', async (request, reply) => {
+    if (!app.env.OPENAI_API_KEY) {
+      return reply.code(503).send({ message: 'Scene image generation is not configured.' });
+    }
+
+    const payload = SceneImageSchema.parse(request.body);
+
+    try {
+      const result = await generateSceneImages(app.env, {
+        sceneTitle: payload.scene_title,
+        pathLabel: payload.path_label,
+        pathSummary: payload.path_summary,
+        prompt: payload.prompt,
+        style: payload.style,
+      });
+
+      return reply.send({
+        scene_id: payload.scene_id,
+        path_id: payload.path_id,
+        prompt: result.prompt,
+        thumbnail: result.thumbnail,
+        full: result.full,
+        generated_at: new Date().toISOString(),
+      });
+    } catch (error) {
+      request.log.error({ err: error }, 'Failed to generate scene images');
+      if (error instanceof SceneImageError) {
+        return reply.code(502).send({ message: error.message });
+      }
+      return reply.code(500).send({ message: 'Unexpected error generating scene image.' });
+    }
+  });
+}

--- a/apps/api/src/services/images.openai.spec.ts
+++ b/apps/api/src/services/images.openai.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { generateSceneImages, SceneImageError, type SceneImageRequest } from './images.openai';
+import type { Env } from '../env';
+
+const baseEnv: Env = {
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'http://localhost:4000',
+  APP_ORIGIN: 'http://localhost:3000',
+  OPENAI_API_KEY: 'test-key',
+  OPENAI_API_BASE_URL: 'https://example.openai.com',
+};
+
+const mockImageResponse = (value: string) => ({
+  ok: true,
+  json: async () => ({ data: [{ b64_json: value }] }),
+});
+
+describe('generateSceneImages', () => {
+  const request: SceneImageRequest = {
+    sceneTitle: 'Boarding the Wreck',
+    pathLabel: 'Investigate the Captain\'s Quarters',
+    pathSummary: 'Search for clues amid creaking boards.',
+    prompt: 'Foggy harbor with spectral silhouettes and lantern light.',
+    style: 'Oil painting with teal highlights',
+  };
+
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch');
+    fetchSpy
+      .mockResolvedValueOnce(mockImageResponse('AAA') as Response)
+      .mockResolvedValueOnce(mockImageResponse('BBB') as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requests OpenAI image generations for full and thumbnail sizes', async () => {
+    const result = await generateSceneImages(baseEnv, request);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://example.openai.com/v1/images/generations',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+
+    const firstCallBody = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    const secondCallBody = JSON.parse(fetchSpy.mock.calls[1][1]?.body as string);
+
+    expect(firstCallBody.size).toBe('1024x1024');
+    expect(secondCallBody.size).toBe('512x512');
+    expect(firstCallBody.prompt).toContain('Scene: Boarding the Wreck');
+    expect(firstCallBody.prompt).toContain('Style: Oil painting');
+
+    expect(result.full).toContain('AAA');
+    expect(result.thumbnail).toContain('BBB');
+  });
+
+  it('throws a SceneImageError when OpenAI is not configured', async () => {
+    const envWithoutKey: Env = { ...baseEnv, OPENAI_API_KEY: undefined };
+    await expect(generateSceneImages(envWithoutKey, request)).rejects.toBeInstanceOf(SceneImageError);
+  });
+});

--- a/apps/api/src/services/images.openai.ts
+++ b/apps/api/src/services/images.openai.ts
@@ -1,0 +1,100 @@
+import { Env } from '../env';
+
+export interface SceneImageRequest {
+  sceneTitle: string;
+  pathLabel: string;
+  pathSummary: string;
+  prompt: string;
+  style?: string;
+}
+
+export interface SceneImageResult {
+  prompt: string;
+  full: string;
+  thumbnail: string;
+  fullSize: string;
+  thumbnailSize: string;
+}
+
+const OPENAI_DEFAULT_BASE = 'https://api.openai.com';
+const OPENAI_IMAGE_MODEL = 'gpt-image-1';
+
+const FULL_SIZE = '1024x1024';
+const THUMBNAIL_SIZE = '512x512';
+
+export class SceneImageError extends Error {}
+
+const toDataUri = (base64: string) => `data:image/png;base64,${base64}`;
+
+const buildPrompt = (request: SceneImageRequest) => {
+  const segments = [
+    `Scene: ${request.sceneTitle}`,
+    `Path: ${request.pathLabel}`,
+    request.pathSummary ? `Summary: ${request.pathSummary}` : undefined,
+    request.prompt,
+    request.style ? `Style: ${request.style}` : undefined,
+    'Cinematic concept art, richly lit, high fidelity.',
+  ].filter(Boolean);
+
+  return segments.join('\n');
+};
+
+async function requestImage(env: Env, prompt: string, size: string): Promise<string> {
+  if (!env.OPENAI_API_KEY) {
+    throw new SceneImageError('OpenAI API key missing');
+  }
+
+  const baseUrl = env.OPENAI_API_BASE_URL?.replace(/\/$/, '') ?? OPENAI_DEFAULT_BASE;
+  const response = await fetch(`${baseUrl}/v1/images/generations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: OPENAI_IMAGE_MODEL,
+      prompt,
+      size,
+      response_format: 'b64_json',
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await safeError(response);
+    throw new SceneImageError(detail ?? 'Failed to generate image');
+  }
+
+  const payload = (await response.json()) as { data?: Array<{ b64_json?: string }>; };
+  const base64 = payload.data?.[0]?.b64_json;
+  if (!base64) {
+    throw new SceneImageError('Image payload missing');
+  }
+
+  return toDataUri(base64);
+}
+
+async function safeError(res: Response) {
+  try {
+    const data = (await res.json()) as { error?: { message?: string } };
+    return data.error?.message;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+export async function generateSceneImages(env: Env, request: SceneImageRequest): Promise<SceneImageResult> {
+  const prompt = buildPrompt(request);
+
+  const [full, thumbnail] = await Promise.all([
+    requestImage(env, prompt, FULL_SIZE),
+    requestImage(env, prompt, THUMBNAIL_SIZE),
+  ]);
+
+  return {
+    prompt,
+    full,
+    thumbnail,
+    fullSize: FULL_SIZE,
+    thumbnailSize: THUMBNAIL_SIZE,
+  };
+}

--- a/apps/web/app/admin/page.module.css
+++ b/apps/web/app/admin/page.module.css
@@ -330,6 +330,210 @@
   color: rgba(148, 163, 184, 0.85);
 }
 
+.sceneImages {
+  display: grid;
+  gap: 24px;
+}
+
+.sceneImagesControls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sceneImagesControls label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.sceneImagesControls select {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: #e2e8f0;
+  font-size: 14px;
+}
+
+.sceneImagesControls p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.sceneImagesPaths {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.scenePathButton {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 18px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  cursor: pointer;
+  color: inherit;
+  transition: border 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  text-align: left;
+}
+
+.scenePathButton:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  transform: translateY(-1px);
+}
+
+.scenePathButtonActive {
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
+}
+
+.scenePathCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scenePathCopy strong {
+  font-size: 15px;
+}
+
+.scenePathCopy span {
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.scenePathThumb {
+  width: 72px;
+  height: 72px;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.scenePathThumb[data-has-image='true'] {
+  border-style: solid;
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.scenePathThumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.scenePathThumb span {
+  font-size: 11px;
+  color: rgba(148, 163, 184, 0.75);
+  text-align: center;
+  padding: 0 8px;
+}
+
+.sceneImagesActions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sceneGenerateButton {
+  align-self: flex-start;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(14, 165, 233, 0.35));
+  border: none;
+  border-radius: 16px;
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #e0f2fe;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.sceneGenerateButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  filter: saturate(0.7);
+}
+
+.scenePromptMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.85);
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 12px 14px;
+}
+
+.scenePromptMeta strong {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.sceneImagesError {
+  margin: 0;
+  font-size: 13px;
+  color: #f87171;
+}
+
+.sceneImagesEmpty {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.scenePreview {
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(8, 11, 23, 0.65);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 320px;
+  justify-content: center;
+  align-items: center;
+}
+
+.scenePreview[data-has-image='true'] {
+  align-items: stretch;
+}
+
+.scenePreview img {
+  width: 100%;
+  border-radius: 18px;
+  object-fit: cover;
+  max-height: 420px;
+}
+
+.scenePreview footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.scenePreviewPlaceholder {
+  text-align: center;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.75);
+  padding: 48px 12px;
+}
+
 @media (max-width: 960px) {
   .panel {
     padding: 24px;


### PR DESCRIPTION
## Summary
- add an OpenAI-powered scene image generation service, Fastify route, and coverage
- update the web admin panel to select scene paths, request art, and preview thumbnails/full images while navigating
- extend the mobile admin console with matching scene imagery controls and previews that call the shared API

## Testing
- pnpm --filter @ovida/api test:unit *(fails: vitest not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e36abec3c48324aa27bd5a2863a796