### PR TITLE
Add DreamHost static export deployment workflow

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -1,0 +1,51 @@
+name: Deploy Ovida Web (Static → DreamHost)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: '20'
+      WEB_DIR: apps/web
+      REMOTE_PATH: ${{ vars.REMOTE_PATH }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install deps (root)
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @ovida/web
+        run: pnpm --filter @ovida/web build
+
+      - name: Static export
+        working-directory: ${{ env.WEB_DIR }}
+        run: npx next export -o out
+
+      - name: Upload via SFTP
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        with:
+          server: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT || '22' }}
+          username: ${{ secrets.SSH_USER }}
+          ssh_private_key: ${{ secrets.SSH_KEY }}
+          local_path: '${{ env.WEB_DIR }}/out/*'
+          remote_path: '${{ env.REMOTE_PATH }}'
+          delete_remote_files: true

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -3,11 +3,11 @@ const nextConfig = {
   reactStrictMode: true,
   output: 'export',
   images: {
-    unoptimized: true
+    unoptimized: true,
   },
   experimental: {
-    typedRoutes: true
-  }
+    typedRoutes: true,
+  },
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "turbo dev",
     "lint": "turbo lint",
     "test": "turbo test",
-    "test:unit": "pnpm --filter @ovida/api test:unit"
+    "test:unit": "pnpm --filter @ovida/api test:unit",
+    "build:web": "pnpm --filter @ovida/web build",
+    "export:web": "pnpm --filter @ovida/web exec next export -o out"
   },
   "devDependencies": {
     "turbo": "^1.13.3"


### PR DESCRIPTION
## Summary
- convert the Next.js config in apps/web to ESM with static export settings
- add root scripts to build and export the web app via pnpm
- add a GitHub Actions workflow to export the web app and deploy via SFTP to DreamHost

## Testing
- not run (pnpm unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e428fe7914832495eaee7e70356b69