### PR TITLE
Add local setup and deployment helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@
    pnpm install
    ```
 
+   Or run the helper script to install dependencies, provision Supabase, and
+   load seed data in one go:
+
+   ```bash
+   ./scripts/setup-local.sh
+   ```
+
+   Pass `--no-supabase`, `--no-seed`, or `--no-install` to customise which steps run.
+
 2. **Start Supabase locally**
 
    ```bash
@@ -47,6 +56,10 @@ See `.env.example` for the environment variables required by each service.
 - `make supabase.up` / `make supabase.down` – manage the local Supabase containers.
 - `make supabase.mig` – applies the latest Supabase migrations to keep the database schema in sync.
 - `make seed` – loads baseline data for development and demo purposes.
+- `scripts/setup-local.sh` – convenience wrapper that installs dependencies
+  and optionally provisions Supabase.
+- `scripts/package-deploy.sh` – builds, runs quality checks, and prepares a
+  deployable bundle identical to the GitHub Actions output.
 
 ### SFTP deployment workflow
 

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: scripts/package-deploy.sh [options]
+
+Builds the monorepo, verifies quality gates, and prepares a deployable bundle
+in the ./deploy directory (matching the GitHub Actions workflow output).
+
+Options:
+  --skip-install   Do not run pnpm install before building.
+  --skip-lint      Do not run pnpm lint before building.
+  --skip-tests     Do not run pnpm test before building.
+  --output DIR     Override the deploy output directory (default: deploy).
+  -h, --help       Show this message and exit.
+USAGE
+}
+
+info() { printf '\033[1;34m[info]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
+error() { printf '\033[1;31m[err]\033[0m %s\n' "$*"; }
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "Required command '$1' is not available."
+    return 1
+  fi
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+run_install=1
+run_lint=1
+run_tests=1
+output_dir="deploy"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-install)
+      run_install=0
+      shift
+      ;;
+    --skip-lint)
+      run_lint=0
+      shift
+      ;;
+    --skip-tests)
+      run_tests=0
+      shift
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        error "--output requires a directory argument"
+        exit 1
+      fi
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+need_cmd pnpm || {
+  error "Install pnpm (https://pnpm.io/installation) before running this script."
+  exit 1
+}
+
+need_cmd rsync || {
+  error "Install rsync to prepare the deployment package."
+  exit 1
+}
+
+if (( run_install )); then
+  info "Installing workspace dependencies"
+  pnpm install
+else
+  info "Skipping dependency installation (per flag)"
+fi
+
+if (( run_lint )); then
+  info "Running lint checks"
+  pnpm lint
+else
+  info "Skipping lint checks (per flag)"
+fi
+
+if (( run_tests )); then
+  info "Running test suite"
+  pnpm test
+else
+  info "Skipping tests (per flag)"
+fi
+
+info "Building workspaces"
+pnpm build
+
+info "Preparing deployment directory at '$output_dir'"
+rm -rf "$output_dir"
+mkdir -p "$output_dir"
+
+rsync -a --delete \
+  --exclude='.git/' \
+  --exclude='.github/' \
+  --exclude='node_modules/' \
+  --exclude="$output_dir/" \
+  --exclude='supabase/.branches/' \
+  ./ "$output_dir"/
+
+bundle_name="$(basename "$output_dir").tar.gz"
+info "Creating archive $bundle_name"
+rm -f "$bundle_name"
+tar -czf "$bundle_name" -C "$output_dir" .
+
+info "Deployment bundle ready: $bundle_name (contents in '$output_dir/')"
+info "Upload the archive via the existing SFTP workflow or preferred channel."

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: scripts/setup-local.sh [options]
+
+Bootstraps the local development environment by installing dependencies,
+ensuring environment files exist, and (optionally) bringing up the Supabase
+stack with the latest migrations and seed data.
+
+Options:
+  --no-install        Skip running pnpm install.
+  --no-supabase       Skip Supabase startup, migrations, and seed data.
+  --no-seed           Skip loading seed data (still starts Supabase unless
+                      --no-supabase is also provided).
+  -h, --help          Show this help message and exit.
+USAGE
+}
+
+info() { printf '\033[1;34m[info]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
+error() { printf '\033[1;31m[err]\033[0m %s\n' "$*"; }
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "Required command '$1' is not available."
+    return 1
+  fi
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+run_install=1
+run_supabase=1
+run_seed=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-install)
+      run_install=0
+      shift
+      ;;
+    --no-supabase)
+      run_supabase=0
+      shift
+      ;;
+    --no-seed)
+      run_seed=0
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+need_cmd pnpm || {
+  error "Install pnpm (https://pnpm.io/installation) before running this script."
+  exit 1
+}
+
+if (( run_supabase )); then
+  missing=()
+  for cmd in supabase docker make; do
+    if ! need_cmd "$cmd"; then
+      missing+=("$cmd")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    error "Supabase setup requested but missing commands: ${missing[*]}"
+    warn "Re-run with --no-supabase to skip Supabase bootstrap."
+    exit 1
+  fi
+fi
+
+if [[ ! -f .env ]]; then
+  info "Creating .env from .env.example"
+  cp .env.example .env
+  warn "Review .env and update credentials before running the services."
+fi
+
+if (( run_install )); then
+  info "Installing workspace dependencies with pnpm"
+  pnpm install
+else
+  info "Skipping pnpm install (per flag)"
+fi
+
+if (( run_supabase )); then
+  info "Starting Supabase containers"
+  make supabase.up
+
+  if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+    source .env >/dev/null 2>&1 || true
+  fi
+
+  if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+    warn "SUPABASE_DB_URL is not set; migrations may fail. Set it in .env."
+  fi
+
+  info "Applying Supabase migrations"
+  make supabase.mig
+
+  if (( run_seed )); then
+    info "Loading seed data"
+    make seed
+  else
+    info "Skipping seed data load (per flag)"
+  fi
+else
+  info "Skipping Supabase bootstrap (per flag)"
+fi
+
+info "Local environment is ready. Use 'make dev' to start the services."


### PR DESCRIPTION
## Summary
- add `scripts/setup-local.sh` to streamline dependency installation and Supabase bootstrap
- add `scripts/package-deploy.sh` to run quality checks and prepare a local deploy bundle
- document the new helper scripts in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4233034348324a9eae5998f545fa9