### PR TITLE
docs: extract release archive into dedicated directory

### DIFF
--- a/docs/deployment-plan.md
+++ b/docs/deployment-plan.md
@@ -108,7 +108,8 @@ jobs:
             set -euo pipefail
             cd ${{ secrets.DEPLOY_PATH }}
             mkdir -p releases current shared
-            tar xzf releases/${{ env.RELEASE_NAME }}.tar.gz -C releases
+            mkdir -p releases/${{ env.RELEASE_NAME }}
+            tar xzf releases/${{ env.RELEASE_NAME }}.tar.gz -C releases/${{ env.RELEASE_NAME }}
             ln -sfn releases/${{ env.RELEASE_NAME }} current
             if [ -n "${{ secrets.DEPLOY_ENV }}" ]; then
               echo "${{ secrets.DEPLOY_ENV }}" > shared/.env.production


### PR DESCRIPTION
## Summary
- ensure the deployment plan extracts release archives into a dedicated release directory before switching the current symlink

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e578dc29d48324bb358f5fb131495b