### PR TITLE
Fix static export regression for dynamic routes

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: 'export',
   images: {
     unoptimized: true
   },


### PR DESCRIPTION
## Summary
- remove the `output: 'export'` configuration from the Next.js app to keep dynamic `[runId]` routes working during build

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e578b777e08324bc92cee9a3ffafed