### PR TITLE
test(api): cover ffmpeg video job API

### DIFF
--- a/apps/api/src/routes/video.jobs.spec.ts
+++ b/apps/api/src/routes/video.jobs.spec.ts
@@ -1,0 +1,184 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../env';
+import { registerVideoJobRoutes } from './video.jobs';
+
+const env: Env = {
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'https://api.example.test',
+  APP_ORIGIN: 'https://app.example.test',
+  OPENAI_API_KEY: undefined,
+  OPENAI_API_BASE_URL: undefined,
+  VIDEO_API_KEY: 'video-secret',
+  VIDEO_TMP_DIR: '/tmp/ovida-video-jobs-test',
+  VIDEO_OUTPUT_DIR: '/tmp/ovida-video-output-test',
+  VIDEO_PUBLIC_BASE_URL: 'https://cdn.example.test/videos/',
+  VIDEO_MAX_INPUT_BYTES: 1_000_000,
+  VIDEO_MAX_OVERLAY_BYTES: 1_000_000,
+  VIDEO_MAX_AUDIO_BYTES: 1_000_000,
+  VIDEO_CALLBACK_TIMEOUT_MS: 1000,
+};
+
+const createVideoJobsMock = () => ({
+  createJob: vi.fn(() => ({
+    job_id: 'job_123',
+    status: 'queued',
+    progress: 0,
+    download_url: null,
+    error: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  })),
+  getJob: vi.fn(),
+});
+
+const buildApp = async (videoJobs = createVideoJobsMock()) => {
+  const app = Fastify({ logger: false });
+  app.decorate('env', env);
+  app.decorate('videoJobs', videoJobs);
+  app.decorate('supabase', {});
+  await registerVideoJobRoutes(app as FastifyInstance);
+  return { app, videoJobs };
+};
+
+describe('video job API routes', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app?.close();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects requests that do not include the video API bearer token', async () => {
+    ({ app } = await buildApp());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/jobs',
+      payload: {
+        source_url: 'https://media.example.test/input.mp4',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ message: 'Missing API key' });
+  });
+
+  it('accepts a valid ffmpeg video job request and returns the status URL', async () => {
+    const setup = await buildApp();
+    app = setup.app;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/jobs',
+      headers: { authorization: 'Bearer video-secret' },
+      payload: {
+        source_url: 'https://media.example.test/input.mp4',
+        overlays: [
+          {
+            type: 'text',
+            text: 'Ovida',
+            fontfile: '/fonts/inter.ttf',
+            fontsize: 48,
+            fontcolor: 'white',
+            x: '(w-text_w)/2',
+            y: 'h-120',
+            start: 0,
+            end: 3,
+            shadow: true,
+          },
+        ],
+        output_format: 'mp4',
+        callback_url: 'https://hooks.example.test/video',
+        audio_url: 'https://media.example.test/audio.mp3',
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toEqual({
+      job_id: 'job_123',
+      status: 'queued',
+      status_url: 'https://api.example.test/api/v1/jobs/job_123',
+    });
+    expect(setup.videoJobs.createJob).toHaveBeenCalledWith({
+      sourceUrl: 'https://media.example.test/input.mp4',
+      overlays: [
+        {
+          type: 'text',
+          text: 'Ovida',
+          fontfile: '/fonts/inter.ttf',
+          fontsize: 48,
+          fontcolor: 'white',
+          x: '(w-text_w)/2',
+          y: 'h-120',
+          start: 0,
+          end: 3,
+          shadow: true,
+        },
+      ],
+      outputFormat: 'mp4',
+      callbackUrl: 'https://hooks.example.test/video',
+      audioUrl: 'https://media.example.test/audio.mp3',
+    });
+  });
+
+  it('returns video job status for authenticated callers', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJob.mockReturnValueOnce({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: null,
+    });
+  });
+
+  it('redirects completed job downloads to the rendered ffmpeg output URL', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJob.mockReturnValueOnce({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done/download',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe('https://cdn.example.test/videos/job_done.mp4');
+  });
+});

--- a/apps/api/src/services/video.jobs.spec.ts
+++ b/apps/api/src/services/video.jobs.spec.ts
@@ -1,0 +1,101 @@
+import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../env';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const { VideoJobManager } = await import('./video.jobs');
+
+const createEnv = (tmpRoot: string, outputRoot: string): Env => ({
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'http://localhost:4000',
+  APP_ORIGIN: 'http://localhost:3000',
+  OPENAI_API_KEY: undefined,
+  OPENAI_API_BASE_URL: undefined,
+  VIDEO_API_KEY: 'video-secret',
+  VIDEO_TMP_DIR: tmpRoot,
+  VIDEO_OUTPUT_DIR: outputRoot,
+  VIDEO_PUBLIC_BASE_URL: 'http://localhost:4000/videos/',
+  VIDEO_MAX_INPUT_BYTES: 1_000_000,
+  VIDEO_MAX_OVERLAY_BYTES: 1_000_000,
+  VIDEO_MAX_AUDIO_BYTES: 1_000_000,
+  VIDEO_CALLBACK_TIMEOUT_MS: 1000,
+});
+
+const createLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+});
+
+const mockSuccessfulChild = () => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit('close', 0));
+  return child;
+};
+
+const mockFailedChild = (error: Error) => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit('error', error));
+  return child;
+};
+
+describe('VideoJobManager ffmpeg environment checks', () => {
+  let tmpRoot: string;
+  let outputRoot: string;
+  let workspace: string;
+
+  beforeEach(async () => {
+    spawnMock.mockReset();
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'ovida-video-jobs-test-'));
+    tmpRoot = path.join(workspace, 'tmp');
+    outputRoot = path.join(workspace, 'out');
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspace, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('creates required directories and verifies ffmpeg and ffprobe are accessible', async () => {
+    spawnMock.mockImplementation(mockSuccessfulChild);
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+
+    await manager.prepareEnvironment();
+
+    expect((await fs.stat(tmpRoot)).isDirectory()).toBe(true);
+    expect((await fs.stat(outputRoot)).isDirectory()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledWith('ffmpeg', ['-version'], { stdio: 'ignore' });
+    expect(spawnMock).toHaveBeenCalledWith('ffprobe', ['-version'], { stdio: 'ignore' });
+  });
+
+  it('fails with an actionable error when ffmpeg is unavailable', async () => {
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'ffmpeg') {
+        return mockFailedChild(new Error('ENOENT'));
+      }
+      return mockSuccessfulChild();
+    });
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+
+    await expect(manager.prepareEnvironment()).rejects.toThrow(
+      'Required executable "ffmpeg" is not available. Install it on the host and ensure it is in PATH. (ENOENT)',
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the ffmpeg/ffprobe-dependent video job subsystem fails fast with a clear error when the executables are missing and verify the service creates its required runtime directories.
- Add unit coverage for the HTTP endpoints that create and query ffmpeg-backed video jobs so request validation, API-key auth, payload mapping, and download redirects are exercised.

### Description
- Add `apps/api/src/services/video.jobs.spec.ts` which mocks `node:child_process.spawn` to simulate `ffmpeg`/`ffprobe` availability and verifies `VideoJobManager.prepareEnvironment()` creates directories and reports an actionable error when `ffmpeg` is unavailable.
- Add `apps/api/src/routes/video.jobs.spec.ts` which spins up a test `Fastify` instance, exercises the POST `/api/v1/jobs` route with and without the `VIDEO_API_KEY` bearer token, verifies payload mapping to the `VideoJobManager`, and checks status and download endpoints and redirects.
- Tests mock external processes and services (spawn, job manager) so the suite runs deterministically without real ffmpeg or network dependencies.

### Testing
- Ran unit tests with `pnpm --filter @ovida/api test:unit`, all tests passed (`28 passed`).
- Type-checked with `pnpm --filter @ovida/api exec tsc -p tsconfig.json --noEmit`, which succeeded.
- Built the package with `pnpm --filter @ovida/api build`, which succeeded.
- Lint step `pnpm --filter @ovida/api lint` failed due to a missing ESLint configuration in the repo (intentional repo-level configuration is not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb55d6f6c83249b52dc0075b0063a)