### PR TITLE
Add video job log endpoint, body limit, admin ffmpeg tool, and tests

### DIFF
--- a/apps/api/dist/routes/video.jobs.js
+++ b/apps/api/dist/routes/video.jobs.js
@@ -65,6 +65,7 @@ const JobParamsSchema = z.object({
     job_id: z.string().min(1),
 });
 export async function registerVideoJobRoutes(app) {
+    const createJobBodyLimit = Math.ceil((app.env.VIDEO_MAX_INPUT_BYTES + app.env.VIDEO_MAX_OVERLAY_BYTES * 10 + app.env.VIDEO_MAX_AUDIO_BYTES) * 1.4);
     const requireApiKey = async (request, reply) => {
         const header = request.headers.authorization;
         if (!header?.startsWith('Bearer ')) {
@@ -76,7 +77,7 @@ export async function registerVideoJobRoutes(app) {
         }
         return undefined;
     };
-    app.post('/api/v1/jobs', { preHandler: requireApiKey }, async (request, reply) => {
+    app.post('/api/v1/jobs', { preHandler: requireApiKey, bodyLimit: createJobBodyLimit }, async (request, reply) => {
         const body = CreateJobBodySchema.parse(request.body);
         const manager = app.videoJobs;
         const payload = mapCreatePayload(body);
@@ -115,6 +116,14 @@ export async function registerVideoJobRoutes(app) {
             return reply.code(404).send({ message: 'Job output not available' });
         }
         return reply.redirect(job.download_url);
+    });
+    app.get('/api/v1/jobs/:job_id/log', { preHandler: requireApiKey }, async (request, reply) => {
+        const { job_id } = JobParamsSchema.parse(request.params);
+        const log = await app.videoJobs.getJobLog(job_id);
+        if (log === undefined) {
+            return reply.code(404).send({ message: 'Job log not found' });
+        }
+        return reply.type('text/plain; charset=utf-8').send(log);
     });
 }
 const mapCreatePayload = (body) => {

--- a/apps/api/dist/services/video.jobs.js
+++ b/apps/api/dist/services/video.jobs.js
@@ -85,6 +85,25 @@ export class VideoJobManager {
         }
         return this.toSummary(job);
     }
+    async getJobLog(jobId) {
+        const job = this.jobs.get(jobId);
+        const candidatePaths = [
+            path.join(this.outputRoot, `${jobId}.log`),
+            job?.logPath,
+        ].filter((candidate) => Boolean(candidate));
+        for (const candidate of candidatePaths) {
+            try {
+                return await fs.readFile(candidate, 'utf8');
+            }
+            catch (error) {
+                const code = error.code;
+                if (code !== 'ENOENT') {
+                    throw error;
+                }
+            }
+        }
+        return undefined;
+    }
     toSummary(job) {
         return {
             job_id: job.id,

--- a/apps/api/src/routes/video.jobs.spec.ts
+++ b/apps/api/src/routes/video.jobs.spec.ts
@@ -1,0 +1,201 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../env';
+import { registerVideoJobRoutes } from './video.jobs';
+
+const env: Env = {
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'https://api.example.test',
+  APP_ORIGIN: 'https://app.example.test',
+  OPENAI_API_KEY: undefined,
+  OPENAI_API_BASE_URL: undefined,
+  VIDEO_API_KEY: 'video-secret',
+  VIDEO_TMP_DIR: '/tmp/ovida-video-jobs-test',
+  VIDEO_OUTPUT_DIR: '/tmp/ovida-video-output-test',
+  VIDEO_PUBLIC_BASE_URL: 'https://cdn.example.test/videos/',
+  VIDEO_MAX_INPUT_BYTES: 1_000_000,
+  VIDEO_MAX_OVERLAY_BYTES: 1_000_000,
+  VIDEO_MAX_AUDIO_BYTES: 1_000_000,
+  VIDEO_CALLBACK_TIMEOUT_MS: 1000,
+};
+
+const createVideoJobsMock = () => ({
+  createJob: vi.fn(() => ({
+    job_id: 'job_123',
+    status: 'queued',
+    progress: 0,
+    download_url: null,
+    error: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  })),
+  getJob: vi.fn(),
+  getJobLog: vi.fn(),
+});
+
+const buildApp = async (videoJobs = createVideoJobsMock()) => {
+  const app = Fastify({ logger: false });
+  app.decorate('env', env);
+  app.decorate('videoJobs', videoJobs);
+  app.decorate('supabase', {});
+  await registerVideoJobRoutes(app as FastifyInstance);
+  return { app, videoJobs };
+};
+
+describe('video job API routes', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app?.close();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects requests that do not include the video API bearer token', async () => {
+    ({ app } = await buildApp());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/jobs',
+      payload: {
+        source_url: 'https://media.example.test/input.mp4',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ message: 'Missing API key' });
+  });
+
+  it('accepts a valid ffmpeg video job request and returns the status URL', async () => {
+    const setup = await buildApp();
+    app = setup.app;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/jobs',
+      headers: { authorization: 'Bearer video-secret' },
+      payload: {
+        source_url: 'https://media.example.test/input.mp4',
+        overlays: [
+          {
+            type: 'text',
+            text: 'Ovida',
+            fontfile: '/fonts/inter.ttf',
+            fontsize: 48,
+            fontcolor: 'white',
+            x: '(w-text_w)/2',
+            y: 'h-120',
+            start: 0,
+            end: 3,
+            shadow: true,
+          },
+        ],
+        output_format: 'mp4',
+        callback_url: 'https://hooks.example.test/video',
+        audio_url: 'https://media.example.test/audio.mp3',
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toEqual({
+      job_id: 'job_123',
+      status: 'queued',
+      status_url: 'https://api.example.test/api/v1/jobs/job_123',
+    });
+    expect(setup.videoJobs.createJob).toHaveBeenCalledWith({
+      sourceUrl: 'https://media.example.test/input.mp4',
+      overlays: [
+        {
+          type: 'text',
+          text: 'Ovida',
+          fontfile: '/fonts/inter.ttf',
+          fontsize: 48,
+          fontcolor: 'white',
+          x: '(w-text_w)/2',
+          y: 'h-120',
+          start: 0,
+          end: 3,
+          shadow: true,
+        },
+      ],
+      outputFormat: 'mp4',
+      callbackUrl: 'https://hooks.example.test/video',
+      audioUrl: 'https://media.example.test/audio.mp3',
+    });
+  });
+
+  it('returns video job status for authenticated callers', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJob.mockReturnValueOnce({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: null,
+    });
+  });
+
+  it('redirects completed job downloads to the rendered ffmpeg output URL', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJob.mockReturnValueOnce({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done/download',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe('https://cdn.example.test/videos/job_done.mp4');
+  });
+
+  it('returns archived ffmpeg logs for authenticated callers', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJobLog.mockResolvedValueOnce('ffmpeg version test\nframe=12 time=00:00:01.00');
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done/log',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/plain');
+    expect(response.body).toContain('frame=12');
+  });
+});

--- a/apps/api/src/routes/video.jobs.ts
+++ b/apps/api/src/routes/video.jobs.ts
@@ -77,6 +77,10 @@ const JobParamsSchema = z.object({
 type CreateJobBody = z.infer<typeof CreateJobBodySchema>;
 type OverlayInput = z.infer<typeof OverlaySchema>;
 export async function registerVideoJobRoutes(app: FastifyInstance) {
+  const createJobBodyLimit = Math.ceil(
+    (app.env.VIDEO_MAX_INPUT_BYTES + app.env.VIDEO_MAX_OVERLAY_BYTES * 10 + app.env.VIDEO_MAX_AUDIO_BYTES) * 1.4,
+  );
+
   const requireApiKey = async (request: FastifyRequest, reply: FastifyReply) => {
     const header = request.headers.authorization;
     if (!header?.startsWith('Bearer ')) {
@@ -89,7 +93,7 @@ export async function registerVideoJobRoutes(app: FastifyInstance) {
     return undefined;
   };
 
-  app.post('/api/v1/jobs', { preHandler: requireApiKey }, async (request, reply) => {
+  app.post('/api/v1/jobs', { preHandler: requireApiKey, bodyLimit: createJobBodyLimit }, async (request, reply) => {
     const body = CreateJobBodySchema.parse(request.body);
     const manager = app.videoJobs;
 
@@ -131,6 +135,15 @@ export async function registerVideoJobRoutes(app: FastifyInstance) {
       return reply.code(404).send({ message: 'Job output not available' });
     }
     return reply.redirect(job.download_url);
+  });
+
+  app.get('/api/v1/jobs/:job_id/log', { preHandler: requireApiKey }, async (request, reply) => {
+    const { job_id } = JobParamsSchema.parse(request.params);
+    const log = await app.videoJobs.getJobLog(job_id);
+    if (log === undefined) {
+      return reply.code(404).send({ message: 'Job log not found' });
+    }
+    return reply.type('text/plain; charset=utf-8').send(log);
   });
 }
 

--- a/apps/api/src/services/video.jobs.spec.ts
+++ b/apps/api/src/services/video.jobs.spec.ts
@@ -1,0 +1,109 @@
+import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../env';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const { VideoJobManager } = await import('./video.jobs');
+
+const createEnv = (tmpRoot: string, outputRoot: string): Env => ({
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'http://localhost:4000',
+  APP_ORIGIN: 'http://localhost:3000',
+  OPENAI_API_KEY: undefined,
+  OPENAI_API_BASE_URL: undefined,
+  VIDEO_API_KEY: 'video-secret',
+  VIDEO_TMP_DIR: tmpRoot,
+  VIDEO_OUTPUT_DIR: outputRoot,
+  VIDEO_PUBLIC_BASE_URL: 'http://localhost:4000/videos/',
+  VIDEO_MAX_INPUT_BYTES: 1_000_000,
+  VIDEO_MAX_OVERLAY_BYTES: 1_000_000,
+  VIDEO_MAX_AUDIO_BYTES: 1_000_000,
+  VIDEO_CALLBACK_TIMEOUT_MS: 1000,
+});
+
+const createLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+});
+
+const mockSuccessfulChild = () => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit('close', 0));
+  return child;
+};
+
+const mockFailedChild = (error: Error) => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit('error', error));
+  return child;
+};
+
+describe('VideoJobManager ffmpeg environment checks', () => {
+  let tmpRoot: string;
+  let outputRoot: string;
+  let workspace: string;
+
+  beforeEach(async () => {
+    spawnMock.mockReset();
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'ovida-video-jobs-test-'));
+    tmpRoot = path.join(workspace, 'tmp');
+    outputRoot = path.join(workspace, 'out');
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspace, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('creates required directories and verifies ffmpeg and ffprobe are accessible', async () => {
+    spawnMock.mockImplementation(mockSuccessfulChild);
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+
+    await manager.prepareEnvironment();
+
+    expect((await fs.stat(tmpRoot)).isDirectory()).toBe(true);
+    expect((await fs.stat(outputRoot)).isDirectory()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledWith('ffmpeg', ['-version'], { stdio: 'ignore' });
+    expect(spawnMock).toHaveBeenCalledWith('ffprobe', ['-version'], { stdio: 'ignore' });
+  });
+
+  it('fails with an actionable error when ffmpeg is unavailable', async () => {
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'ffmpeg') {
+        return mockFailedChild(new Error('ENOENT'));
+      }
+      return mockSuccessfulChild();
+    });
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+
+    await expect(manager.prepareEnvironment()).rejects.toThrow(
+      'Required executable "ffmpeg" is not available. Install it on the host and ensure it is in PATH. (ENOENT)',
+    );
+  });
+
+  it('reads archived ffmpeg logs from the output directory', async () => {
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+    await fs.mkdir(outputRoot, { recursive: true });
+    await fs.writeFile(path.join(outputRoot, 'job_abc.log'), 'ffmpeg diagnostic output', 'utf8');
+
+    await expect(manager.getJobLog('job_abc')).resolves.toBe('ffmpeg diagnostic output');
+  });
+});

--- a/apps/api/src/services/video.jobs.ts
+++ b/apps/api/src/services/video.jobs.ts
@@ -174,6 +174,27 @@ export class VideoJobManager {
     return this.toSummary(job);
   }
 
+  async getJobLog(jobId: string): Promise<string | undefined> {
+    const job = this.jobs.get(jobId);
+    const candidatePaths = [
+      path.join(this.outputRoot, `${jobId}.log`),
+      job?.logPath,
+    ].filter((candidate): candidate is string => Boolean(candidate));
+
+    for (const candidate of candidatePaths) {
+      try {
+        return await fs.readFile(candidate, 'utf8');
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
   private toSummary(job: VideoJobInternal): VideoJobSummary {
     return {
       job_id: job.id,

--- a/apps/web/app/admin/api-status/page.tsx
+++ b/apps/web/app/admin/api-status/page.tsx
@@ -43,14 +43,16 @@ export default function ApiStatusPage() {
   const endpoints = useMemo(() => API_CATEGORY_DEFINITIONS, []);
 
   const updateStatus = useCallback((testId: string, update: Partial<EndpointStatus>) => {
-    setStatuses((prev) => ({
-      ...prev,
-      [testId]: {
-        state: prev[testId]?.state ?? 'idle',
-        ...prev[testId],
-        ...update,
-      },
-    }));
+    setStatuses((prev) => {
+      const current = prev[testId] ?? { state: 'idle' as EndpointState };
+      return {
+        ...prev,
+        [testId]: {
+          ...current,
+          ...update,
+        },
+      };
+    });
   }, []);
 
   const resolveOrigin = useCallback(

--- a/apps/web/app/admin/api-tests/page.module.css
+++ b/apps/web/app/admin/api-tests/page.module.css
@@ -404,3 +404,126 @@
     align-self: flex-start;
   }
 }
+
+.ffmpegSection {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.82));
+  border: 1px solid rgba(56, 189, 248, 0.22);
+  border-radius: 24px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  box-shadow: 0 18px 48px rgba(8, 47, 73, 0.28);
+}
+
+.ffmpegHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.ffmpegHeader h2,
+.ffmpegResults h3 {
+  margin: 0;
+}
+
+.ffmpegHeader p {
+  max-width: 760px;
+  margin: 8px 0 0;
+  color: rgba(203, 213, 225, 0.86);
+  line-height: 1.5;
+}
+
+.downloadLink {
+  flex: 0 0 auto;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(74, 222, 128, 0.16);
+  border: 1px solid rgba(74, 222, 128, 0.45);
+  color: #bbf7d0;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.ffmpegGrid,
+.ffmpegControls,
+.ffmpegResults {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.fileField,
+.compactField {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.56);
+}
+
+.fileField span,
+.compactField span {
+  color: rgba(148, 163, 184, 0.86);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.fileField small {
+  color: rgba(203, 213, 225, 0.72);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.fileField input,
+.compactField input,
+.compactField select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  padding: 10px 12px;
+  background: rgba(2, 6, 23, 0.45);
+  color: inherit;
+}
+
+.fileField input:focus-visible,
+.compactField input:focus-visible,
+.compactField select:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.18);
+}
+
+.ffmpegResults {
+  align-items: stretch;
+}
+
+.ffmpegResults > div {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.ffmpegResults h3 {
+  font-size: 15px;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+@media (max-width: 720px) {
+  .ffmpegHeader {
+    flex-direction: column;
+  }
+
+  .downloadLink {
+    align-self: stretch;
+    text-align: center;
+  }
+}

--- a/apps/web/app/admin/api-tests/page.tsx
+++ b/apps/web/app/admin/api-tests/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { type ChangeEvent, useMemo, useState } from 'react';
 import {
   API_CATEGORY_DEFINITIONS,
   type ApiCategory,
@@ -65,12 +65,60 @@ const formatResponseBody = (payload: string) => {
 
 const methodLabel = (method: ApiTestDefinition['method']) => method.toUpperCase();
 
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => resolve(String(reader.result ?? '')));
+    reader.addEventListener('error', () => reject(reader.error ?? new Error('Unable to read file')));
+    reader.readAsDataURL(file);
+  });
+
+const formatFileLabel = (file?: File | null) => {
+  if (!file) return 'No file selected';
+  const sizeMb = file.size / 1024 / 1024;
+  return `${file.name} · ${sizeMb.toFixed(sizeMb >= 10 ? 1 : 2)} MB`;
+};
+
+type FfmpegToolStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type FfmpegToolState = {
+  sourceFile?: File | null;
+  sourceDataUrl?: string;
+  logoFile?: File | null;
+  logoDataUrl?: string;
+  audioFile?: File | null;
+  audioDataUrl?: string;
+  videoApiKey: string;
+  jobId: string;
+  status: FfmpegToolStatus;
+  message: string;
+  result: string;
+  log: string;
+  downloadUrl?: string;
+  outputFormat: 'mp4' | 'mov' | 'mkv';
+  overlayText: string;
+  fontFile: string;
+};
+
+const getInitialFfmpegToolState = (): FfmpegToolState => ({
+  videoApiKey: '',
+  jobId: '',
+  status: 'idle',
+  message: 'Upload a source video, optionally add logo/audio assets, then run a render.',
+  result: '',
+  log: '',
+  outputFormat: 'mp4',
+  overlayText: 'OVIDA TEST RENDER',
+  fontFile: '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+});
+
 export default function ApiTestToolsPage() {
   const [origins, setOrigins] = useState<Record<ApiCategory, string>>({
     internal: apiOrigin,
     external: defaultExternalOrigin,
   });
   const [requests, setRequests] = useState<Record<string, RequestState>>(() => createInitialState());
+  const [ffmpegTool, setFfmpegTool] = useState<FfmpegToolState>(() => getInitialFfmpegToolState());
 
   const allTests = useMemo(
     () =>
@@ -202,6 +250,224 @@ export default function ApiTestToolsPage() {
     }
   };
 
+
+  const buildExternalApiUrl = (path: string) => {
+    const origin = origins.external?.trim().replace(/\/+$/, '');
+    if (!origin) {
+      throw new Error('Set the External API Origin before running the ffmpeg tool.');
+    }
+    return `${origin}${path.startsWith('/') ? path : `/${path}`}`;
+  };
+
+  const updateFfmpegFile = async (
+    field: 'source' | 'logo' | 'audio',
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        [`${field}File`]: null,
+        [`${field}DataUrl`]: undefined,
+      }));
+      return;
+    }
+
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'loading',
+      message: `Reading ${file.name}…`,
+    }));
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setFfmpegTool((prev) => ({
+        ...prev,
+        [`${field}File`]: file,
+        [`${field}DataUrl`]: dataUrl,
+        status: 'idle',
+        message: `${file.name} is ready for the ffmpeg API request.`,
+      }));
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to read selected file.',
+      }));
+    }
+  };
+
+  const fetchFfmpegLog = async (jobId: string, apiKey: string) => {
+    const response = await fetch(buildExternalApiUrl(`/api/v1/jobs/${jobId}/log`), {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return text.trim() ? formatResponseBody(text) : `${response.status} ${response.statusText}`;
+    }
+    return text.trim() || '∅ Log is empty';
+  };
+
+  const checkFfmpegStatus = async (jobId = ffmpegTool.jobId, apiKey = ffmpegTool.videoApiKey) => {
+    const trimmedJobId = jobId.trim();
+    const trimmedApiKey = apiKey.trim();
+    if (!trimmedJobId || !trimmedApiKey) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: 'Provide both a job ID and VIDEO_API_KEY before checking status.',
+      }));
+      return null;
+    }
+
+    setFfmpegTool((prev) => ({ ...prev, status: 'loading', message: `Checking ${trimmedJobId}…` }));
+
+    try {
+      const response = await fetch(buildExternalApiUrl(`/api/v1/jobs/${trimmedJobId}`), {
+        headers: { Authorization: `Bearer ${trimmedApiKey}` },
+      });
+      const text = await response.text();
+      const formatted = formatResponseBody(text);
+      let parsed: { status?: string; download_url?: string | null; error?: string | null } | null = null;
+      try {
+        parsed = text.trim() ? JSON.parse(text) : null;
+      } catch {
+        parsed = null;
+      }
+
+      const log = await fetchFfmpegLog(trimmedJobId, trimmedApiKey);
+      const succeeded = response.ok && parsed?.status !== 'failed';
+      setFfmpegTool((prev) => ({
+        ...prev,
+        jobId: trimmedJobId,
+        status: succeeded ? 'success' : 'error',
+        message: response.ok
+          ? `Job ${trimmedJobId} is ${parsed?.status ?? 'unknown'}.`
+          : `Status request failed: ${response.status} ${response.statusText}`,
+        result: formatted,
+        log,
+        downloadUrl: parsed?.download_url ?? prev.downloadUrl,
+      }));
+      return parsed;
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to check ffmpeg job status.',
+      }));
+      return null;
+    }
+  };
+
+  const pollFfmpegJob = async (jobId: string, apiKey: string) => {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, attempt === 0 ? 1000 : 2000));
+      const status = await checkFfmpegStatus(jobId, apiKey);
+      if (status?.status === 'completed' || status?.status === 'failed') {
+        return;
+      }
+    }
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'success',
+      message: 'Polling timed out after 60 seconds. Use Check status/log to continue watching the job.',
+    }));
+  };
+
+  const runFfmpegTool = async () => {
+    const apiKey = ffmpegTool.videoApiKey.trim();
+    if (!apiKey) {
+      setFfmpegTool((prev) => ({ ...prev, status: 'error', message: 'Enter a VIDEO_API_KEY before running.' }));
+      return;
+    }
+    if (!ffmpegTool.sourceDataUrl) {
+      setFfmpegTool((prev) => ({ ...prev, status: 'error', message: 'Upload a source video before running.' }));
+      return;
+    }
+
+    const payload = {
+      source_url: ffmpegTool.sourceDataUrl,
+      overlays: [
+        {
+          type: 'text',
+          text: ffmpegTool.overlayText,
+          fontfile: ffmpegTool.fontFile,
+          fontsize: 48,
+          fontcolor: 'white',
+          x: '(w-text_w)/2',
+          y: 'h-96',
+          start: 0,
+          end: 4,
+          shadow: true,
+        },
+        ...(ffmpegTool.logoDataUrl
+          ? [
+              {
+                type: 'logo',
+                asset_url: ffmpegTool.logoDataUrl,
+                x: 'main_w-overlay_w-32',
+                y: 'main_h-overlay_h-32',
+                start: 0,
+                end: 6,
+                fade_in: 0.25,
+                fade_out: 0.25,
+                scale: '0.25',
+              },
+            ]
+          : []),
+      ],
+      output_format: ffmpegTool.outputFormat,
+      ...(ffmpegTool.audioDataUrl ? { audio_url: ffmpegTool.audioDataUrl } : {}),
+    };
+
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'loading',
+      message: 'Submitting ffmpeg render job…',
+      result: JSON.stringify(payload, (key, value) => (String(value).startsWith('data:') ? '[uploaded data URL]' : value), 2),
+      log: '',
+      downloadUrl: undefined,
+    }));
+
+    try {
+      const response = await fetch(buildExternalApiUrl('/api/v1/jobs'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const text = await response.text();
+      const formatted = formatResponseBody(text);
+      const parsed = text.trim() ? JSON.parse(text) as { job_id?: string } : null;
+      if (!response.ok || !parsed?.job_id) {
+        setFfmpegTool((prev) => ({
+          ...prev,
+          status: 'error',
+          message: `Create job failed: ${response.status} ${response.statusText}`,
+          result: formatted,
+        }));
+        return;
+      }
+
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'success',
+        message: `Created ${parsed.job_id}. Polling status and ffmpeg log…`,
+        jobId: parsed.job_id!,
+        result: formatted,
+      }));
+      await pollFfmpegJob(parsed.job_id, apiKey);
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to run ffmpeg API test.',
+      }));
+    }
+  };
+
   return (
     <div className={styles.page}>
       <header className={styles.header}>
@@ -242,6 +508,116 @@ export default function ApiTestToolsPage() {
               </small>
             </label>
           ))}
+        </div>
+      </section>
+
+
+      <section className={styles.ffmpegSection}>
+        <div className={styles.ffmpegHeader}>
+          <div>
+            <p className={styles.eyebrow}>ffmpeg workflow</p>
+            <h2>Upload Assets & Run Video Job</h2>
+            <p>
+              Convert local test assets to data URLs, submit them to the ffmpeg API, poll for results,
+              and fetch the archived render log without leaving the admin test page.
+            </p>
+          </div>
+          {ffmpegTool.downloadUrl ? (
+            <a className={styles.downloadLink} href={ffmpegTool.downloadUrl} target="_blank" rel="noreferrer">
+              Open rendered video ↗
+            </a>
+          ) : null}
+        </div>
+
+        <div className={styles.ffmpegGrid}>
+          <label className={styles.fileField}>
+            <span>Source video</span>
+            <input type="file" accept="video/mp4,video/quicktime,video/x-matroska" onChange={(event) => updateFfmpegFile('source', event)} />
+            <small>{formatFileLabel(ffmpegTool.sourceFile)}</small>
+          </label>
+          <label className={styles.fileField}>
+            <span>Logo overlay</span>
+            <input type="file" accept="image/png,image/jpeg,image/webp,image/gif" onChange={(event) => updateFfmpegFile('logo', event)} />
+            <small>{formatFileLabel(ffmpegTool.logoFile)}</small>
+          </label>
+          <label className={styles.fileField}>
+            <span>Replacement audio</span>
+            <input type="file" accept="audio/mpeg,audio/wav,audio/x-wav" onChange={(event) => updateFfmpegFile('audio', event)} />
+            <small>{formatFileLabel(ffmpegTool.audioFile)}</small>
+          </label>
+        </div>
+
+        <div className={styles.ffmpegControls}>
+          <label className={styles.compactField}>
+            <span>VIDEO_API_KEY</span>
+            <input
+              type="password"
+              value={ffmpegTool.videoApiKey}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, videoApiKey: event.target.value }))}
+              placeholder="Bearer token value"
+            />
+          </label>
+          <label className={styles.compactField}>
+            <span>Job ID</span>
+            <input
+              value={ffmpegTool.jobId}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, jobId: event.target.value }))}
+              placeholder="job_..."
+            />
+          </label>
+          <label className={styles.compactField}>
+            <span>Output</span>
+            <select
+              value={ffmpegTool.outputFormat}
+              onChange={(event) =>
+                setFfmpegTool((prev) => ({ ...prev, outputFormat: event.target.value as FfmpegToolState['outputFormat'] }))
+              }
+            >
+              <option value="mp4">MP4</option>
+              <option value="mov">MOV</option>
+              <option value="mkv">MKV</option>
+            </select>
+          </label>
+          <label className={styles.compactField}>
+            <span>Text overlay</span>
+            <input
+              value={ffmpegTool.overlayText}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, overlayText: event.target.value }))}
+            />
+          </label>
+          <label className={styles.compactField}>
+            <span>Font file on API host</span>
+            <input
+              value={ffmpegTool.fontFile}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, fontFile: event.target.value }))}
+            />
+          </label>
+        </div>
+
+        <div className={styles.actions}>
+          <button type="button" onClick={runFfmpegTool} disabled={ffmpegTool.status === 'loading'}>
+            {ffmpegTool.status === 'loading' ? 'Running…' : 'Upload & Run ffmpeg Job'}
+          </button>
+          <button type="button" className={styles.resetButton} onClick={() => checkFfmpegStatus()} disabled={ffmpegTool.status === 'loading'}>
+            Check status/log
+          </button>
+          <button type="button" className={styles.resetButton} onClick={() => setFfmpegTool(getInitialFfmpegToolState())}>
+            Reset ffmpeg tool
+          </button>
+        </div>
+
+        <div className={styles.result} data-status={ffmpegTool.status}>
+          <p className={styles.resultStatus}>{ffmpegTool.message}</p>
+          <div className={styles.ffmpegResults}>
+            <div>
+              <h3>Job result</h3>
+              <pre className={styles.responseBody}>{ffmpegTool.result || 'Create or check a job to see status JSON.'}</pre>
+            </div>
+            <div>
+              <h3>ffmpeg log</h3>
+              <pre className={styles.responseBody}>{ffmpegTool.log || 'Log output appears after the API archives or exposes it.'}</pre>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -2,7 +2,14 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
+const isStaticExport = process.env.NEXT_SHOULD_EXPORT === 'true';
+
 export async function GET(request: Request) {
+  if (isStaticExport) {
+    const origin = process.env.NEXT_PUBLIC_APP_ORIGIN ?? 'http://localhost:3000';
+    return NextResponse.redirect(new URL('/admin', origin));
+  }
+
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get('code');
 

--- a/apps/web/app/auth/session/route.ts
+++ b/apps/web/app/auth/session/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from 'next/server';
 import { apiOrigin } from '@/lib/config';
 
+const isStaticExport = process.env.NEXT_SHOULD_EXPORT === 'true';
+
 export async function GET(request: Request) {
+  if (isStaticExport) {
+    return NextResponse.json({ user: null, profile: null });
+  }
+
   const accessToken = request.headers.get('sb-access-token');
 
   if (!accessToken) {

--- a/apps/web/lib/api-endpoints.ts
+++ b/apps/web/lib/api-endpoints.ts
@@ -248,6 +248,19 @@ export const API_CATEGORY_DEFINITIONS: ApiCategoryDefinition[] = [
         },
         notice: 'Successful jobs redirect to the generated asset URL.',
       },
+      {
+        id: 'external-video-log',
+        label: 'Fetch Video Job Log',
+        method: 'GET',
+        path: '/api/v1/jobs/job_12345/log',
+        description: 'Fetch the archived ffmpeg log for a video render job.',
+        category: 'external',
+        allowBody: false,
+        defaultHeaders: {
+          Authorization: 'Bearer <VIDEO_API_KEY>',
+        },
+        notice: 'Replace job_12345 with the identifier returned from the create job request.',
+      },
     ],
   },
 ];

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -7,4 +7,7 @@ if (!supabaseUrl || !supabaseAnonKey) {
   console.warn('Supabase environment variables not configured');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const supabaseClientUrl = supabaseUrl || 'http://localhost:54321';
+const supabaseClientAnonKey = supabaseAnonKey || 'local-anon-key';
+
+export const supabase = createClient(supabaseClientUrl, supabaseClientAnonKey);


### PR DESCRIPTION
### Motivation
- Provide a way to retrieve archived ffmpeg logs for video render jobs and make the create-job endpoint tolerant to large payloads. 
- Improve developer/admin UX by adding an on-page ffmpeg test tool to submit assets and inspect job/log output. 
- Harden runtime behavior for static exports and local development by adding sensible fallbacks and small bug fixes. 

### Description
- API: compute a `createJobBodyLimit` from `VIDEO_MAX_*` env vars and apply it to the `POST /api/v1/jobs` route, and add a new `GET /api/v1/jobs/:job_id/log` route that requires the API key and returns archived logs as `text/plain`.
- Services: implement `VideoJobManager.getJobLog(jobId)` to read archived log files from the output directory or job-provided `logPath` and return their contents or `undefined` if missing.
- Tests: add unit tests for the routes in `apps/api/src/routes/video.jobs.spec.ts` and for the service environment/log behavior in `apps/api/src/services/video.jobs.spec.ts`.
- Web/admin: add an ffmpeg workflow tool UI to `apps/web/app/admin/api-tests/page.tsx` with associated styles in `page.module.css`, add an `external-video-log` definition to `lib/api-endpoints.ts`, and improve the `api-status` update merging logic in `app/admin/api-status/page.tsx`.
- Misc: make `supabase` client use local fallbacks in `apps/web/lib/supabase.ts` and handle static-export behavior in `apps/web/app/auth/callback/route.ts` and `apps/web/app/auth/session/route.ts`.

### Testing
- Ran the new route unit tests in `apps/api/src/routes/video.jobs.spec.ts` with `vitest`, which exercise `POST /api/v1/jobs`, `GET /api/v1/jobs/:job_id`, `GET /api/v1/jobs/:job_id/download`, and `GET /api/v1/jobs/:job_id/log`, and they passed.
- Ran the service unit tests in `apps/api/src/services/video.jobs.spec.ts` with `vitest`, which verify environment preparation, ffmpeg/ffprobe checks, and `getJobLog` behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb55d6f6c83249b52dc0075b0063a)