### PR TITLE
Build & deploy API runtime; add ffmpeg job endpoints, admin test tooling, and static API gateway

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
       NODE_VERSION: '20'
       WEB_DIR: apps/web
       BUILD_OUTPUT_DIR: apps/web/out
+      API_BUNDLE_PATH: api-deploy/ovida-api-runtime.tar.gz
+      API_REMOTE_PATH: ${{ vars.API_REMOTE_PATH != '' && vars.API_REMOTE_PATH || secrets.API_REMOTE_PATH }}
       REMOTE_PATH: ${{ vars.REMOTE_PATH != '' && vars.REMOTE_PATH || secrets.REMOTE_PATH }}
       NEXT_TELEMETRY_DISABLED: 1
 
@@ -43,6 +45,31 @@ jobs:
         env:
           NODE_ENV: production
 
+      - name: Build API service
+        run: |
+          pnpm --filter @ovida/schemas build
+          pnpm --filter @ovida/api build
+
+      - name: Package API service
+        env:
+          API_ENV: ${{ secrets.API_ENV }}
+        run: |
+          set -euo pipefail
+          mkdir -p api-deploy
+          tar -czf "${API_BUNDLE_PATH}" \
+            package.json \
+            pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            apps/api/package.json \
+            apps/api/dist \
+            packages/schemas/package.json \
+            packages/schemas/dist
+
+          if [ -n "${API_ENV}" ]; then
+            printf '%s\n' "${API_ENV}" > api-deploy/api.env
+            chmod 600 api-deploy/api.env
+          fi
+
       - name: Verify build output
         run: |
           echo "Checking build output..."
@@ -64,6 +91,21 @@ jobs:
             exit 1
           fi
 
+          if [ ! -f "${API_BUNDLE_PATH}" ]; then
+            echo "❌ Error: API bundle not found at ${API_BUNDLE_PATH}!"
+            exit 1
+          fi
+
+          if [ ! -f "${BUILD_OUTPUT_DIR}/api/index.php" ]; then
+            echo "❌ Error: API gateway was not exported into ${BUILD_OUTPUT_DIR}/api/index.php!"
+            exit 1
+          fi
+
+          if [ ! -f "${BUILD_OUTPUT_DIR}/.htaccess" ]; then
+            echo "❌ Error: Apache rewrite file was not exported into ${BUILD_OUTPUT_DIR}/.htaccess!"
+            exit 1
+          fi
+
       - name: Validate deployment configuration
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -71,6 +113,7 @@ jobs:
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
           REMOTE_PATH: ${{ env.REMOTE_PATH }}
+          API_BUNDLE_PATH: ${{ env.API_BUNDLE_PATH }}
         run: |
           set -euo pipefail
           missing=()
@@ -118,6 +161,7 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           LOCAL_BUILD_DIR: ${{ env.BUILD_OUTPUT_DIR }}
           REMOTE_PATH: ${{ env.REMOTE_PATH }}
+          API_BUNDLE_PATH: ${{ env.API_BUNDLE_PATH }}
         run: |
           set -euo pipefail
 
@@ -160,6 +204,149 @@ jobs:
             echo "❌ No SSH credentials provided. Set SSH_PASSWORD or SSH_KEY."
             exit 1
           fi
+
+      - name: Upload API bundle via SCP
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
+          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_BUNDLE_PATH: ${{ env.API_BUNDLE_PATH }}
+          REMOTE_PATH: ${{ env.REMOTE_PATH }}
+        run: |
+          set -euo pipefail
+
+          REMOTE_DIR="${REMOTE_PATH%/}"
+          if [ -z "${REMOTE_DIR}" ]; then
+            REMOTE_DIR="/"
+          fi
+
+          DEST="${SSH_USER}@${SSH_HOST}:${REMOTE_DIR}/"
+          echo "📦 Uploading API bundle to ${DEST}"
+
+          if [ -n "${SSH_PASSWORD}" ]; then
+            if ! command -v sshpass >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y sshpass
+            fi
+
+            sshpass -p "${SSH_PASSWORD}" \
+              scp -P "${SSH_PORT}" -o StrictHostKeyChecking=no "${API_BUNDLE_PATH}" "${DEST}"
+            if [ -f api-deploy/api.env ]; then
+              sshpass -p "${SSH_PASSWORD}" \
+                scp -P "${SSH_PORT}" -o StrictHostKeyChecking=no api-deploy/api.env "${DEST}"
+            fi
+          elif [ -n "${SSH_KEY}" ]; then
+            mkdir -p ~/.ssh
+            KEY_FILE=~/.ssh/id_deploy_api
+            printf '%s\n' "${SSH_KEY}" > "${KEY_FILE}"
+            chmod 600 "${KEY_FILE}"
+
+            scp -i "${KEY_FILE}" -P "${SSH_PORT}" -o StrictHostKeyChecking=no "${API_BUNDLE_PATH}" "${DEST}"
+            if [ -f api-deploy/api.env ]; then
+              scp -i "${KEY_FILE}" -P "${SSH_PORT}" -o StrictHostKeyChecking=no api-deploy/api.env "${DEST}"
+            fi
+            rm -f "${KEY_FILE}"
+          else
+            echo "❌ No SSH credentials provided. Set SSH_PASSWORD or SSH_KEY."
+            exit 1
+          fi
+
+      - name: Deploy and start API service
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          REMOTE_PATH: ${{ env.REMOTE_PATH }}
+          API_REMOTE_PATH: ${{ env.API_REMOTE_PATH }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || '22' }}
+          envs: REMOTE_PATH,API_REMOTE_PATH
+          script: |
+            set -euo pipefail
+
+            REMOTE_DIR="${REMOTE_PATH%/}"
+            if [ -z "${REMOTE_DIR}" ]; then
+              REMOTE_DIR="/"
+            fi
+
+            API_DIR="${API_REMOTE_PATH:-$(dirname "${REMOTE_DIR}")/ovida-api}"
+            API_ARCHIVE="${REMOTE_DIR}/ovida-api-runtime.tar.gz"
+            API_ENV_UPLOAD="${REMOTE_DIR}/api.env"
+            API_NAME="ovida-api"
+
+            if [ ! -f "${API_ARCHIVE}" ]; then
+              echo "❌ API archive ${API_ARCHIVE} was not uploaded."
+              exit 1
+            fi
+
+            mkdir -p "${API_DIR}"
+            tar -xzf "${API_ARCHIVE}" -C "${API_DIR}"
+            rm -f "${API_ARCHIVE}"
+
+            if [ -f "${API_ENV_UPLOAD}" ]; then
+              mkdir -p "${API_DIR}/apps/api"
+              mv "${API_ENV_UPLOAD}" "${API_DIR}/apps/api/.env"
+              chmod 600 "${API_DIR}/apps/api/.env"
+            elif [ ! -f "${API_DIR}/apps/api/.env" ]; then
+              echo "❌ Missing API environment file."
+              echo "Create ${API_DIR}/apps/api/.env on the VPS or set the GitHub secret API_ENV."
+              echo "Required values include SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, VIDEO_API_KEY, APP_ORIGIN, and API_ORIGIN."
+              exit 1
+            fi
+
+            cd "${API_DIR}"
+            if command -v corepack >/dev/null 2>&1; then
+              corepack enable
+              corepack prepare pnpm@8.15.6 --activate
+            fi
+            if ! command -v pnpm >/dev/null 2>&1; then
+              npm install -g pnpm@8.15.6
+            fi
+
+            pnpm install --prod --frozen-lockfile --filter @ovida/api...
+
+            cd "${API_DIR}/apps/api"
+            mkdir -p "${API_DIR}/logs" "${API_DIR}/pids"
+
+            if command -v pm2 >/dev/null 2>&1; then
+              if pm2 describe "${API_NAME}" >/dev/null 2>&1; then
+                pm2 restart "${API_NAME}" --update-env
+              else
+                pm2 start dist/index.js --name "${API_NAME}" --update-env
+              fi
+              pm2 save || true
+            else
+              if [ -f "${API_DIR}/pids/api.pid" ]; then
+                old_pid="$(cat "${API_DIR}/pids/api.pid")"
+                if [ -n "${old_pid}" ]; then
+                  kill "${old_pid}" 2>/dev/null || true
+                fi
+              fi
+              nohup node dist/index.js > "${API_DIR}/logs/api.log" 2>&1 &
+              echo $! > "${API_DIR}/pids/api.pid"
+            fi
+
+            for attempt in 1 2 3 4 5 6 7 8 9 10; do
+              status="$(curl -s -o /tmp/ovida-api-health.txt -w '%{http_code}' http://127.0.0.1:4000/api/v1/jobs/deploy-smoke || true)"
+              if [ "${status}" = "401" ] || [ "${status}" = "404" ]; then
+                echo "✅ API service is reachable on http://127.0.0.1:4000 (HTTP ${status})."
+                exit 0
+              fi
+              echo "Waiting for API service on 127.0.0.1:4000 (attempt ${attempt}, HTTP ${status})..."
+              sleep 2
+            done
+
+            echo "❌ API service did not become reachable on http://127.0.0.1:4000."
+            if command -v pm2 >/dev/null 2>&1; then
+              pm2 logs "${API_NAME}" --lines 80 --nostream || true
+            else
+              tail -n 80 "${API_DIR}/logs/api.log" || true
+            fi
+            exit 1
 
       - name: Verify remote upload
         uses: appleboy/ssh-action@v1.0.3

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -88,6 +88,7 @@ GOOGLE_CLIENT_SECRET=your_client_secret_here
    - Go to Authentication > Providers
    - Enable Google
    - Add your Client ID and Secret
+   - Add your app callback URLs under Authentication > URL Configuration, including `http://localhost:3000/admin` and `https://your-domain.example/admin`
 
 ### 3. Run Database Migrations
 
@@ -102,6 +103,7 @@ Migrations include:
 - `0001_init.sql` - Initial schema with profiles table
 - `0002_profiles_roles.sql` - Add role column and constraints
 - `0003_admin_user_setup.sql` - Auto-assign admin role to designated users
+- `0004_auth_profile_provisioning.sql` - Create profile rows from Supabase Auth users after OAuth sign-in
 
 ### 4. Set Admin User
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,7 +1,7 @@
 # Deployment Guide
 
 ## Overview
-This repository uses GitHub Actions to automatically deploy the Ovida web application to DreamHost VPS when changes are pushed to the `main` branch.
+This repository uses GitHub Actions to automatically deploy the Ovida static web application and Fastify API service to DreamHost VPS when changes are pushed to the `main` branch.
 
 ## Deployment Status: ✅ Fixed & Ready for Configuration
 
@@ -41,7 +41,34 @@ This repository uses GitHub Actions to automatically deploy the Ovida web applic
 
 > **Note**: You may need to verify the correct path by SSH-ing into your server first.
 
-### Step 3: Verify Remote Path
+### Step 3: Configure API Service Startup
+
+The web deploy is a static Apache export, but `/api/*` is proxied to the Fastify API on the same VPS at `127.0.0.1:4000`. The primary GitHub Actions workflow now builds, uploads, installs, starts, and smoke-tests that API service during deploy.
+
+Add one of the following before running the deployment:
+
+1. **Recommended:** add a repository secret named `API_ENV` containing the production `apps/api/.env` content. At minimum it must include:
+   ```bash
+   NODE_ENV=production
+   PORT=4000
+   APP_ORIGIN=https://ovida.1976.cloud
+   API_ORIGIN=https://ovida.1976.cloud
+   SUPABASE_URL=...
+   SUPABASE_ANON_KEY=...
+   SUPABASE_SERVICE_ROLE_KEY=...
+   VIDEO_API_KEY=...
+   ```
+2. **Manual VPS fallback:** create the file once on the server at the API deploy path, which defaults to a sibling of the web root named `ovida-api/apps/api/.env`.
+
+Optional repository variable/secret:
+
+| Name | Value |
+|------|-------|
+| `API_REMOTE_PATH` | Absolute VPS path for the API runtime bundle. Defaults to a sibling directory named `ovida-api` next to `REMOTE_PATH`. |
+
+The workflow uses PM2 when it is installed; otherwise it starts `node dist/index.js` with `nohup` and writes a PID file. It then checks `http://127.0.0.1:4000/api/v1/jobs/deploy-smoke`, which should return `401` without an API key when the Fastify service is reachable.
+
+### Step 4: Verify Remote Path
 
 SSH into your server to confirm the deployment directory:
 
@@ -69,7 +96,7 @@ Update the `REMOTE_PATH` variable if needed.
 ### Primary: SFTP Deployment
 - **Workflow**: `.github/workflows/deploy.yml`
 - **Trigger**: Automatic on push to `main` branch
-- **Method**: SFTP upload using password authentication
+- **Method**: SCP static web upload plus API runtime bundle upload/start using password or key authentication
 
 ### Alternative: SSH/SCP Deployment
 - **Workflow**: `.github/workflows/deploy-alternative.yml`

--- a/apps/api/dist/routes/video.jobs.js
+++ b/apps/api/dist/routes/video.jobs.js
@@ -65,6 +65,7 @@ const JobParamsSchema = z.object({
     job_id: z.string().min(1),
 });
 export async function registerVideoJobRoutes(app) {
+    const createJobBodyLimit = Math.ceil((app.env.VIDEO_MAX_INPUT_BYTES + app.env.VIDEO_MAX_OVERLAY_BYTES * 10 + app.env.VIDEO_MAX_AUDIO_BYTES) * 1.4);
     const requireApiKey = async (request, reply) => {
         const header = request.headers.authorization;
         if (!header?.startsWith('Bearer ')) {
@@ -76,7 +77,7 @@ export async function registerVideoJobRoutes(app) {
         }
         return undefined;
     };
-    app.post('/api/v1/jobs', { preHandler: requireApiKey }, async (request, reply) => {
+    app.post('/api/v1/jobs', { preHandler: requireApiKey, bodyLimit: createJobBodyLimit }, async (request, reply) => {
         const body = CreateJobBodySchema.parse(request.body);
         const manager = app.videoJobs;
         const payload = mapCreatePayload(body);
@@ -115,6 +116,14 @@ export async function registerVideoJobRoutes(app) {
             return reply.code(404).send({ message: 'Job output not available' });
         }
         return reply.redirect(job.download_url);
+    });
+    app.get('/api/v1/jobs/:job_id/log', { preHandler: requireApiKey }, async (request, reply) => {
+        const { job_id } = JobParamsSchema.parse(request.params);
+        const log = await app.videoJobs.getJobLog(job_id);
+        if (log === undefined) {
+            return reply.code(404).send({ message: 'Job log not found' });
+        }
+        return reply.type('text/plain; charset=utf-8').send(log);
     });
 }
 const mapCreatePayload = (body) => {

--- a/apps/api/dist/services/video.jobs.js
+++ b/apps/api/dist/services/video.jobs.js
@@ -85,6 +85,28 @@ export class VideoJobManager {
         }
         return this.toSummary(job);
     }
+    async getJobLog(jobId) {
+        const job = this.jobs.get(jobId);
+        if (!job) {
+            return undefined;
+        }
+        const candidatePaths = [
+            job.logPath,
+            path.join(this.outputRoot, `${job.id}.log`),
+        ].filter((candidate) => Boolean(candidate));
+        for (const candidate of candidatePaths) {
+            try {
+                return await fs.readFile(candidate, 'utf8');
+            }
+            catch (error) {
+                const code = error.code;
+                if (code !== 'ENOENT') {
+                    throw error;
+                }
+            }
+        }
+        return undefined;
+    }
     toSummary(job) {
         return {
             job_id: job.id,

--- a/apps/api/src/routes/video.jobs.spec.ts
+++ b/apps/api/src/routes/video.jobs.spec.ts
@@ -1,0 +1,201 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../env';
+import { registerVideoJobRoutes } from './video.jobs';
+
+const env: Env = {
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'https://api.example.test',
+  APP_ORIGIN: 'https://app.example.test',
+  OPENAI_API_KEY: undefined,
+  OPENAI_API_BASE_URL: undefined,
+  VIDEO_API_KEY: 'video-secret',
+  VIDEO_TMP_DIR: '/tmp/ovida-video-jobs-test',
+  VIDEO_OUTPUT_DIR: '/tmp/ovida-video-output-test',
+  VIDEO_PUBLIC_BASE_URL: 'https://cdn.example.test/videos/',
+  VIDEO_MAX_INPUT_BYTES: 1_000_000,
+  VIDEO_MAX_OVERLAY_BYTES: 1_000_000,
+  VIDEO_MAX_AUDIO_BYTES: 1_000_000,
+  VIDEO_CALLBACK_TIMEOUT_MS: 1000,
+};
+
+const createVideoJobsMock = () => ({
+  createJob: vi.fn(() => ({
+    job_id: 'job_123',
+    status: 'queued',
+    progress: 0,
+    download_url: null,
+    error: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  })),
+  getJob: vi.fn(),
+  getJobLog: vi.fn(),
+});
+
+const buildApp = async (videoJobs = createVideoJobsMock()) => {
+  const app = Fastify({ logger: false });
+  app.decorate('env', env);
+  app.decorate('videoJobs', videoJobs);
+  app.decorate('supabase', {});
+  await registerVideoJobRoutes(app as FastifyInstance);
+  return { app, videoJobs };
+};
+
+describe('video job API routes', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app?.close();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects requests that do not include the video API bearer token', async () => {
+    ({ app } = await buildApp());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/jobs',
+      payload: {
+        source_url: 'https://media.example.test/input.mp4',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ message: 'Missing API key' });
+  });
+
+  it('accepts a valid ffmpeg video job request and returns the status URL', async () => {
+    const setup = await buildApp();
+    app = setup.app;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/jobs',
+      headers: { authorization: 'Bearer video-secret' },
+      payload: {
+        source_url: 'https://media.example.test/input.mp4',
+        overlays: [
+          {
+            type: 'text',
+            text: 'Ovida',
+            fontfile: '/fonts/inter.ttf',
+            fontsize: 48,
+            fontcolor: 'white',
+            x: '(w-text_w)/2',
+            y: 'h-120',
+            start: 0,
+            end: 3,
+            shadow: true,
+          },
+        ],
+        output_format: 'mp4',
+        callback_url: 'https://hooks.example.test/video',
+        audio_url: 'https://media.example.test/audio.mp3',
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toEqual({
+      job_id: 'job_123',
+      status: 'queued',
+      status_url: 'https://api.example.test/api/v1/jobs/job_123',
+    });
+    expect(setup.videoJobs.createJob).toHaveBeenCalledWith({
+      sourceUrl: 'https://media.example.test/input.mp4',
+      overlays: [
+        {
+          type: 'text',
+          text: 'Ovida',
+          fontfile: '/fonts/inter.ttf',
+          fontsize: 48,
+          fontcolor: 'white',
+          x: '(w-text_w)/2',
+          y: 'h-120',
+          start: 0,
+          end: 3,
+          shadow: true,
+        },
+      ],
+      outputFormat: 'mp4',
+      callbackUrl: 'https://hooks.example.test/video',
+      audioUrl: 'https://media.example.test/audio.mp3',
+    });
+  });
+
+  it('returns video job status for authenticated callers', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJob.mockReturnValueOnce({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: null,
+    });
+  });
+
+  it('redirects completed job downloads to the rendered ffmpeg output URL', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJob.mockReturnValueOnce({
+      job_id: 'job_done',
+      status: 'completed',
+      progress: 100,
+      download_url: 'https://cdn.example.test/videos/job_done.mp4',
+      error: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done/download',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe('https://cdn.example.test/videos/job_done.mp4');
+  });
+
+  it('returns archived ffmpeg logs for authenticated callers', async () => {
+    const videoJobs = createVideoJobsMock();
+    videoJobs.getJobLog.mockResolvedValueOnce('ffmpeg version test\nframe=12 time=00:00:01.00');
+    ({ app } = await buildApp(videoJobs));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/jobs/job_done/log',
+      headers: { authorization: 'Bearer video-secret' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/plain');
+    expect(response.body).toContain('frame=12');
+  });
+});

--- a/apps/api/src/routes/video.jobs.ts
+++ b/apps/api/src/routes/video.jobs.ts
@@ -77,6 +77,10 @@ const JobParamsSchema = z.object({
 type CreateJobBody = z.infer<typeof CreateJobBodySchema>;
 type OverlayInput = z.infer<typeof OverlaySchema>;
 export async function registerVideoJobRoutes(app: FastifyInstance) {
+  const createJobBodyLimit = Math.ceil(
+    (app.env.VIDEO_MAX_INPUT_BYTES + app.env.VIDEO_MAX_OVERLAY_BYTES * 10 + app.env.VIDEO_MAX_AUDIO_BYTES) * 1.4,
+  );
+
   const requireApiKey = async (request: FastifyRequest, reply: FastifyReply) => {
     const header = request.headers.authorization;
     if (!header?.startsWith('Bearer ')) {
@@ -89,7 +93,7 @@ export async function registerVideoJobRoutes(app: FastifyInstance) {
     return undefined;
   };
 
-  app.post('/api/v1/jobs', { preHandler: requireApiKey }, async (request, reply) => {
+  app.post('/api/v1/jobs', { preHandler: requireApiKey, bodyLimit: createJobBodyLimit }, async (request, reply) => {
     const body = CreateJobBodySchema.parse(request.body);
     const manager = app.videoJobs;
 
@@ -131,6 +135,15 @@ export async function registerVideoJobRoutes(app: FastifyInstance) {
       return reply.code(404).send({ message: 'Job output not available' });
     }
     return reply.redirect(job.download_url);
+  });
+
+  app.get('/api/v1/jobs/:job_id/log', { preHandler: requireApiKey }, async (request, reply) => {
+    const { job_id } = JobParamsSchema.parse(request.params);
+    const log = await app.videoJobs.getJobLog(job_id);
+    if (log === undefined) {
+      return reply.code(404).send({ message: 'Job log not found' });
+    }
+    return reply.type('text/plain; charset=utf-8').send(log);
   });
 }
 

--- a/apps/api/src/services/video.jobs.spec.ts
+++ b/apps/api/src/services/video.jobs.spec.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../env';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const { VideoJobManager } = await import('./video.jobs');
+
+const createEnv = (tmpRoot: string, outputRoot: string): Env => ({
+  NODE_ENV: 'test',
+  PORT: 4000,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ELEVENLABS_API_KEY: undefined,
+  ELEVENLABS_VOICE_ID: 'voice',
+  ELEVENLABS_MODEL: 'model',
+  ELEVENLABS_STREAMING: 'off',
+  API_ORIGIN: 'http://localhost:4000',
+  APP_ORIGIN: 'http://localhost:3000',
+  OPENAI_API_KEY: undefined,
+  OPENAI_API_BASE_URL: undefined,
+  VIDEO_API_KEY: 'video-secret',
+  VIDEO_TMP_DIR: tmpRoot,
+  VIDEO_OUTPUT_DIR: outputRoot,
+  VIDEO_PUBLIC_BASE_URL: 'http://localhost:4000/videos/',
+  VIDEO_MAX_INPUT_BYTES: 1_000_000,
+  VIDEO_MAX_OVERLAY_BYTES: 1_000_000,
+  VIDEO_MAX_AUDIO_BYTES: 1_000_000,
+  VIDEO_CALLBACK_TIMEOUT_MS: 1000,
+});
+
+const createLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+});
+
+const mockSuccessfulChild = () => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit('close', 0));
+  return child;
+};
+
+const mockFailedChild = (error: Error) => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit('error', error));
+  return child;
+};
+
+describe('VideoJobManager ffmpeg environment checks', () => {
+  let tmpRoot: string;
+  let outputRoot: string;
+  let workspace: string;
+
+  beforeEach(async () => {
+    spawnMock.mockReset();
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'ovida-video-jobs-test-'));
+    tmpRoot = path.join(workspace, 'tmp');
+    outputRoot = path.join(workspace, 'out');
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspace, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('creates required directories and verifies ffmpeg and ffprobe are accessible', async () => {
+    spawnMock.mockImplementation(mockSuccessfulChild);
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+
+    await manager.prepareEnvironment();
+
+    expect((await fs.stat(tmpRoot)).isDirectory()).toBe(true);
+    expect((await fs.stat(outputRoot)).isDirectory()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledWith('ffmpeg', ['-version'], { stdio: 'ignore' });
+    expect(spawnMock).toHaveBeenCalledWith('ffprobe', ['-version'], { stdio: 'ignore' });
+  });
+
+  it('fails with an actionable error when ffmpeg is unavailable', async () => {
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'ffmpeg') {
+        return mockFailedChild(new Error('ENOENT'));
+      }
+      return mockSuccessfulChild();
+    });
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+
+    await expect(manager.prepareEnvironment()).rejects.toThrow(
+      'Required executable "ffmpeg" is not available. Install it on the host and ensure it is in PATH. (ENOENT)',
+    );
+  });
+
+  it('reads archived ffmpeg logs for known jobs from the output directory', async () => {
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+    const jobId = 'job_abc';
+    (manager as any).jobs.set(jobId, { id: jobId });
+    await fs.mkdir(outputRoot, { recursive: true });
+    await fs.writeFile(path.join(outputRoot, `${jobId}.log`), 'ffmpeg diagnostic output', 'utf8');
+
+    await expect(manager.getJobLog(jobId)).resolves.toBe('ffmpeg diagnostic output');
+  });
+
+  it('does not read arbitrary log paths for unknown job ids', async () => {
+    const manager = new VideoJobManager({ env: createEnv(tmpRoot, outputRoot), logger: createLogger() as any });
+    await fs.mkdir(path.dirname(outputRoot), { recursive: true });
+    await fs.writeFile(path.join(path.dirname(outputRoot), 'other-service.log'), 'sensitive log output', 'utf8');
+
+    await expect(manager.getJobLog('../other-service')).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/services/video.jobs.ts
+++ b/apps/api/src/services/video.jobs.ts
@@ -174,6 +174,31 @@ export class VideoJobManager {
     return this.toSummary(job);
   }
 
+  async getJobLog(jobId: string): Promise<string | undefined> {
+    const job = this.jobs.get(jobId);
+    if (!job) {
+      return undefined;
+    }
+
+    const candidatePaths = [
+      job.logPath,
+      path.join(this.outputRoot, `${job.id}.log`),
+    ].filter((candidate): candidate is string => Boolean(candidate));
+
+    for (const candidate of candidatePaths) {
+      try {
+        return await fs.readFile(candidate, 'utf8');
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
   private toSummary(job: VideoJobInternal): VideoJobSummary {
     return {
       job_id: job.id,

--- a/apps/web/app/admin/api-status/page.tsx
+++ b/apps/web/app/admin/api-status/page.tsx
@@ -43,14 +43,16 @@ export default function ApiStatusPage() {
   const endpoints = useMemo(() => API_CATEGORY_DEFINITIONS, []);
 
   const updateStatus = useCallback((testId: string, update: Partial<EndpointStatus>) => {
-    setStatuses((prev) => ({
-      ...prev,
-      [testId]: {
-        state: prev[testId]?.state ?? 'idle',
-        ...prev[testId],
-        ...update,
-      },
-    }));
+    setStatuses((prev) => {
+      const current = prev[testId] ?? { state: 'idle' as EndpointState };
+      return {
+        ...prev,
+        [testId]: {
+          ...current,
+          ...update,
+        },
+      };
+    });
   }, []);
 
   const resolveOrigin = useCallback(

--- a/apps/web/app/admin/api-tests/page.module.css
+++ b/apps/web/app/admin/api-tests/page.module.css
@@ -404,3 +404,126 @@
     align-self: flex-start;
   }
 }
+
+.ffmpegSection {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.82));
+  border: 1px solid rgba(56, 189, 248, 0.22);
+  border-radius: 24px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  box-shadow: 0 18px 48px rgba(8, 47, 73, 0.28);
+}
+
+.ffmpegHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.ffmpegHeader h2,
+.ffmpegResults h3 {
+  margin: 0;
+}
+
+.ffmpegHeader p {
+  max-width: 760px;
+  margin: 8px 0 0;
+  color: rgba(203, 213, 225, 0.86);
+  line-height: 1.5;
+}
+
+.downloadLink {
+  flex: 0 0 auto;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(74, 222, 128, 0.16);
+  border: 1px solid rgba(74, 222, 128, 0.45);
+  color: #bbf7d0;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.ffmpegGrid,
+.ffmpegControls,
+.ffmpegResults {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.fileField,
+.compactField {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.56);
+}
+
+.fileField span,
+.compactField span {
+  color: rgba(148, 163, 184, 0.86);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.fileField small {
+  color: rgba(203, 213, 225, 0.72);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.fileField input,
+.compactField input,
+.compactField select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  padding: 10px 12px;
+  background: rgba(2, 6, 23, 0.45);
+  color: inherit;
+}
+
+.fileField input:focus-visible,
+.compactField input:focus-visible,
+.compactField select:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.18);
+}
+
+.ffmpegResults {
+  align-items: stretch;
+}
+
+.ffmpegResults > div {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.ffmpegResults h3 {
+  font-size: 15px;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+@media (max-width: 720px) {
+  .ffmpegHeader {
+    flex-direction: column;
+  }
+
+  .downloadLink {
+    align-self: stretch;
+    text-align: center;
+  }
+}

--- a/apps/web/app/admin/api-tests/page.tsx
+++ b/apps/web/app/admin/api-tests/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { type ChangeEvent, useMemo, useState } from 'react';
 import {
   API_CATEGORY_DEFINITIONS,
   type ApiCategory,
@@ -65,12 +65,60 @@ const formatResponseBody = (payload: string) => {
 
 const methodLabel = (method: ApiTestDefinition['method']) => method.toUpperCase();
 
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => resolve(String(reader.result ?? '')));
+    reader.addEventListener('error', () => reject(reader.error ?? new Error('Unable to read file')));
+    reader.readAsDataURL(file);
+  });
+
+const formatFileLabel = (file?: File | null) => {
+  if (!file) return 'No file selected';
+  const sizeMb = file.size / 1024 / 1024;
+  return `${file.name} · ${sizeMb.toFixed(sizeMb >= 10 ? 1 : 2)} MB`;
+};
+
+type FfmpegToolStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type FfmpegToolState = {
+  sourceFile?: File | null;
+  sourceDataUrl?: string;
+  logoFile?: File | null;
+  logoDataUrl?: string;
+  audioFile?: File | null;
+  audioDataUrl?: string;
+  videoApiKey: string;
+  jobId: string;
+  status: FfmpegToolStatus;
+  message: string;
+  result: string;
+  log: string;
+  downloadUrl?: string;
+  outputFormat: 'mp4' | 'mov' | 'mkv';
+  overlayText: string;
+  fontFile: string;
+};
+
+const getInitialFfmpegToolState = (): FfmpegToolState => ({
+  videoApiKey: '',
+  jobId: '',
+  status: 'idle',
+  message: 'Upload a source video, optionally add logo/audio assets, then run a render.',
+  result: '',
+  log: '',
+  outputFormat: 'mp4',
+  overlayText: 'OVIDA TEST RENDER',
+  fontFile: '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+});
+
 export default function ApiTestToolsPage() {
   const [origins, setOrigins] = useState<Record<ApiCategory, string>>({
     internal: apiOrigin,
     external: defaultExternalOrigin,
   });
   const [requests, setRequests] = useState<Record<string, RequestState>>(() => createInitialState());
+  const [ffmpegTool, setFfmpegTool] = useState<FfmpegToolState>(() => getInitialFfmpegToolState());
 
   const allTests = useMemo(
     () =>
@@ -202,6 +250,224 @@ export default function ApiTestToolsPage() {
     }
   };
 
+
+  const buildExternalApiUrl = (path: string) => {
+    const origin = origins.external?.trim().replace(/\/+$/, '');
+    if (!origin) {
+      throw new Error('Set the External API Origin before running the ffmpeg tool.');
+    }
+    return `${origin}${path.startsWith('/') ? path : `/${path}`}`;
+  };
+
+  const updateFfmpegFile = async (
+    field: 'source' | 'logo' | 'audio',
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        [`${field}File`]: null,
+        [`${field}DataUrl`]: undefined,
+      }));
+      return;
+    }
+
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'loading',
+      message: `Reading ${file.name}…`,
+    }));
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setFfmpegTool((prev) => ({
+        ...prev,
+        [`${field}File`]: file,
+        [`${field}DataUrl`]: dataUrl,
+        status: 'idle',
+        message: `${file.name} is ready for the ffmpeg API request.`,
+      }));
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to read selected file.',
+      }));
+    }
+  };
+
+  const fetchFfmpegLog = async (jobId: string, apiKey: string) => {
+    const response = await fetch(buildExternalApiUrl(`/api/v1/jobs/${jobId}/log`), {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return text.trim() ? formatResponseBody(text) : `${response.status} ${response.statusText}`;
+    }
+    return text.trim() || '∅ Log is empty';
+  };
+
+  const checkFfmpegStatus = async (jobId = ffmpegTool.jobId, apiKey = ffmpegTool.videoApiKey) => {
+    const trimmedJobId = jobId.trim();
+    const trimmedApiKey = apiKey.trim();
+    if (!trimmedJobId || !trimmedApiKey) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: 'Provide both a job ID and VIDEO_API_KEY before checking status.',
+      }));
+      return null;
+    }
+
+    setFfmpegTool((prev) => ({ ...prev, status: 'loading', message: `Checking ${trimmedJobId}…` }));
+
+    try {
+      const response = await fetch(buildExternalApiUrl(`/api/v1/jobs/${trimmedJobId}`), {
+        headers: { Authorization: `Bearer ${trimmedApiKey}` },
+      });
+      const text = await response.text();
+      const formatted = formatResponseBody(text);
+      let parsed: { status?: string; download_url?: string | null; error?: string | null } | null = null;
+      try {
+        parsed = text.trim() ? JSON.parse(text) : null;
+      } catch {
+        parsed = null;
+      }
+
+      const log = await fetchFfmpegLog(trimmedJobId, trimmedApiKey);
+      const succeeded = response.ok && parsed?.status !== 'failed';
+      setFfmpegTool((prev) => ({
+        ...prev,
+        jobId: trimmedJobId,
+        status: succeeded ? 'success' : 'error',
+        message: response.ok
+          ? `Job ${trimmedJobId} is ${parsed?.status ?? 'unknown'}.`
+          : `Status request failed: ${response.status} ${response.statusText}`,
+        result: formatted,
+        log,
+        downloadUrl: parsed?.download_url ?? prev.downloadUrl,
+      }));
+      return parsed;
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to check ffmpeg job status.',
+      }));
+      return null;
+    }
+  };
+
+  const pollFfmpegJob = async (jobId: string, apiKey: string) => {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, attempt === 0 ? 1000 : 2000));
+      const status = await checkFfmpegStatus(jobId, apiKey);
+      if (status?.status === 'completed' || status?.status === 'failed') {
+        return;
+      }
+    }
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'success',
+      message: 'Polling timed out after 60 seconds. Use Check status/log to continue watching the job.',
+    }));
+  };
+
+  const runFfmpegTool = async () => {
+    const apiKey = ffmpegTool.videoApiKey.trim();
+    if (!apiKey) {
+      setFfmpegTool((prev) => ({ ...prev, status: 'error', message: 'Enter a VIDEO_API_KEY before running.' }));
+      return;
+    }
+    if (!ffmpegTool.sourceDataUrl) {
+      setFfmpegTool((prev) => ({ ...prev, status: 'error', message: 'Upload a source video before running.' }));
+      return;
+    }
+
+    const payload = {
+      source_url: ffmpegTool.sourceDataUrl,
+      overlays: [
+        {
+          type: 'text',
+          text: ffmpegTool.overlayText,
+          fontfile: ffmpegTool.fontFile,
+          fontsize: 48,
+          fontcolor: 'white',
+          x: '(w-text_w)/2',
+          y: 'h-96',
+          start: 0,
+          end: 4,
+          shadow: true,
+        },
+        ...(ffmpegTool.logoDataUrl
+          ? [
+              {
+                type: 'logo',
+                asset_url: ffmpegTool.logoDataUrl,
+                x: 'main_w-overlay_w-32',
+                y: 'main_h-overlay_h-32',
+                start: 0,
+                end: 6,
+                fade_in: 0.25,
+                fade_out: 0.25,
+                scale: '0.25',
+              },
+            ]
+          : []),
+      ],
+      output_format: ffmpegTool.outputFormat,
+      ...(ffmpegTool.audioDataUrl ? { audio_url: ffmpegTool.audioDataUrl } : {}),
+    };
+
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'loading',
+      message: 'Submitting ffmpeg render job…',
+      result: JSON.stringify(payload, (key, value) => (String(value).startsWith('data:') ? '[uploaded data URL]' : value), 2),
+      log: '',
+      downloadUrl: undefined,
+    }));
+
+    try {
+      const response = await fetch(buildExternalApiUrl('/api/v1/jobs'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const text = await response.text();
+      const formatted = formatResponseBody(text);
+      const parsed = text.trim() ? JSON.parse(text) as { job_id?: string } : null;
+      if (!response.ok || !parsed?.job_id) {
+        setFfmpegTool((prev) => ({
+          ...prev,
+          status: 'error',
+          message: `Create job failed: ${response.status} ${response.statusText}`,
+          result: formatted,
+        }));
+        return;
+      }
+
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'success',
+        message: `Created ${parsed.job_id}. Polling status and ffmpeg log…`,
+        jobId: parsed.job_id!,
+        result: formatted,
+      }));
+      await pollFfmpegJob(parsed.job_id, apiKey);
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to run ffmpeg API test.',
+      }));
+    }
+  };
+
   return (
     <div className={styles.page}>
       <header className={styles.header}>
@@ -242,6 +508,116 @@ export default function ApiTestToolsPage() {
               </small>
             </label>
           ))}
+        </div>
+      </section>
+
+
+      <section id="ffmpeg-api-tool" className={styles.ffmpegSection}>
+        <div className={styles.ffmpegHeader}>
+          <div>
+            <p className={styles.eyebrow}>ffmpeg workflow</p>
+            <h2>Upload Assets & Run Video Job</h2>
+            <p>
+              Convert local test assets to data URLs, submit them to the ffmpeg API, poll for results,
+              and fetch the archived render log without leaving the admin test page.
+            </p>
+          </div>
+          {ffmpegTool.downloadUrl ? (
+            <a className={styles.downloadLink} href={ffmpegTool.downloadUrl} target="_blank" rel="noreferrer">
+              Open rendered video ↗
+            </a>
+          ) : null}
+        </div>
+
+        <div className={styles.ffmpegGrid}>
+          <label className={styles.fileField}>
+            <span>Source video</span>
+            <input type="file" accept="video/mp4,video/quicktime,video/x-matroska" onChange={(event) => updateFfmpegFile('source', event)} />
+            <small>{formatFileLabel(ffmpegTool.sourceFile)}</small>
+          </label>
+          <label className={styles.fileField}>
+            <span>Logo overlay</span>
+            <input type="file" accept="image/png,image/jpeg,image/webp,image/gif" onChange={(event) => updateFfmpegFile('logo', event)} />
+            <small>{formatFileLabel(ffmpegTool.logoFile)}</small>
+          </label>
+          <label className={styles.fileField}>
+            <span>Replacement audio</span>
+            <input type="file" accept="audio/mpeg,audio/wav,audio/x-wav" onChange={(event) => updateFfmpegFile('audio', event)} />
+            <small>{formatFileLabel(ffmpegTool.audioFile)}</small>
+          </label>
+        </div>
+
+        <div className={styles.ffmpegControls}>
+          <label className={styles.compactField}>
+            <span>VIDEO_API_KEY</span>
+            <input
+              type="password"
+              value={ffmpegTool.videoApiKey}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, videoApiKey: event.target.value }))}
+              placeholder="Bearer token value"
+            />
+          </label>
+          <label className={styles.compactField}>
+            <span>Job ID</span>
+            <input
+              value={ffmpegTool.jobId}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, jobId: event.target.value }))}
+              placeholder="job_..."
+            />
+          </label>
+          <label className={styles.compactField}>
+            <span>Output</span>
+            <select
+              value={ffmpegTool.outputFormat}
+              onChange={(event) =>
+                setFfmpegTool((prev) => ({ ...prev, outputFormat: event.target.value as FfmpegToolState['outputFormat'] }))
+              }
+            >
+              <option value="mp4">MP4</option>
+              <option value="mov">MOV</option>
+              <option value="mkv">MKV</option>
+            </select>
+          </label>
+          <label className={styles.compactField}>
+            <span>Text overlay</span>
+            <input
+              value={ffmpegTool.overlayText}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, overlayText: event.target.value }))}
+            />
+          </label>
+          <label className={styles.compactField}>
+            <span>Font file on API host</span>
+            <input
+              value={ffmpegTool.fontFile}
+              onChange={(event) => setFfmpegTool((prev) => ({ ...prev, fontFile: event.target.value }))}
+            />
+          </label>
+        </div>
+
+        <div className={styles.actions}>
+          <button type="button" onClick={runFfmpegTool} disabled={ffmpegTool.status === 'loading'}>
+            {ffmpegTool.status === 'loading' ? 'Running…' : 'Upload & Run ffmpeg Job'}
+          </button>
+          <button type="button" className={styles.resetButton} onClick={() => checkFfmpegStatus()} disabled={ffmpegTool.status === 'loading'}>
+            Check status/log
+          </button>
+          <button type="button" className={styles.resetButton} onClick={() => setFfmpegTool(getInitialFfmpegToolState())}>
+            Reset ffmpeg tool
+          </button>
+        </div>
+
+        <div className={styles.result} data-status={ffmpegTool.status}>
+          <p className={styles.resultStatus}>{ffmpegTool.message}</p>
+          <div className={styles.ffmpegResults}>
+            <div>
+              <h3>Job result</h3>
+              <pre className={styles.responseBody}>{ffmpegTool.result || 'Create or check a job to see status JSON.'}</pre>
+            </div>
+            <div>
+              <h3>ffmpeg log</h3>
+              <pre className={styles.responseBody}>{ffmpegTool.log || 'Log output appears after the API archives or exposes it.'}</pre>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -298,20 +298,25 @@ export default function AdminPage() {
           <span>Live endpoint status plus default test harness</span>
         </header>
         <p className={styles.panelCopy}>
-          Monitor every internal and partner-facing route from the console. Flip between the live status board and
-          the default test harness to validate payloads, latency, and headers in a few clicks.
+          Monitor every internal and partner-facing route from the console. Open the API test tools at
+          <strong> /admin/api-tests</strong>, or jump straight into the ffmpeg workflow to upload assets, run a
+          render, and inspect job logs.
         </p>
         <div className={styles.apiActions}>
           <Link href="/admin/api-status" className={styles.primaryLink}>
             View Endpoint Status
           </Link>
           <Link href="/admin/api-tests" className={styles.secondaryLink}>
-            Open Test Harness
+            Open API Test Tools
+          </Link>
+          <Link href="/admin/api-tests#ffmpeg-api-tool" className={styles.secondaryLink}>
+            Open ffmpeg API Tool
           </Link>
         </div>
         <ul className={styles.apiList}>
           <li>See availability, status codes, and probe latency for every endpoint.</li>
           <li>Run pre-filled demo, run, room, imagery, and video job requests with default settings.</li>
+          <li>Use the ffmpeg API tool to upload source, logo, and audio assets, then view job results and logs.</li>
           <li>Swap origins to verify staging or partner environments without leaving the admin space.</li>
         </ul>
       </section>

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -2,7 +2,14 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
+const isStaticExport = process.env.NEXT_SHOULD_EXPORT === 'true';
+
 export async function GET(request: Request) {
+  if (isStaticExport) {
+    const origin = process.env.NEXT_PUBLIC_APP_ORIGIN ?? 'http://localhost:3000';
+    return NextResponse.redirect(new URL('/admin', origin));
+  }
+
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get('code');
 

--- a/apps/web/app/auth/session/route.ts
+++ b/apps/web/app/auth/session/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from 'next/server';
 import { apiOrigin } from '@/lib/config';
 
+const isStaticExport = process.env.NEXT_SHOULD_EXPORT === 'true';
+
 export async function GET(request: Request) {
+  if (isStaticExport) {
+    return NextResponse.json({ user: null, profile: null });
+  }
+
   const accessToken = request.headers.get('sb-access-token');
 
   if (!accessToken) {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 <Link href={{ pathname: '/replay', query: { runId: 'demo' } }}>Replay</Link>
                 <Link href={{ pathname: '/room', query: { runId: 'demo' } }}>Room</Link>
                 <Link href="/admin">Admin</Link>
+                <Link href="/admin/api-tests">API Tests</Link>
               </nav>
             </aside>
             <main className={styles.main}>{children}</main>

--- a/apps/web/components/auth-guard.tsx
+++ b/apps/web/components/auth-guard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
 
@@ -10,7 +11,7 @@ interface AuthGuardProps {
 }
 
 export const AuthGuard: React.FC<AuthGuardProps> = ({ children, requireAdmin = false }) => {
-  const { user, profile, loading, isAdmin, signInWithGoogle } = useAuth();
+  const { user, profile, loading, isAdmin, signInWithGoogle, authError } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
@@ -53,6 +54,9 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, requireAdmin = f
         gap: '20px'
       }}>
         <div>Authentication required</div>
+        {authError ? (
+          <div style={{ color: '#f87171', maxWidth: '360px', textAlign: 'center' }}>{authError}</div>
+        ) : null}
         <button
           onClick={signInWithGoogle}
           style={{
@@ -67,6 +71,16 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, requireAdmin = f
         >
           Sign in with Google
         </button>
+        <Link
+          href="/admin/api-tests"
+          style={{
+            color: '#93c5fd',
+            fontSize: '14px',
+            textDecoration: 'underline'
+          }}
+        >
+          Open API Test Tools
+        </Link>
       </div>
     );
   }

--- a/apps/web/lib/api-endpoints.ts
+++ b/apps/web/lib/api-endpoints.ts
@@ -248,6 +248,19 @@ export const API_CATEGORY_DEFINITIONS: ApiCategoryDefinition[] = [
         },
         notice: 'Successful jobs redirect to the generated asset URL.',
       },
+      {
+        id: 'external-video-log',
+        label: 'Fetch Video Job Log',
+        method: 'GET',
+        path: '/api/v1/jobs/job_12345/log',
+        description: 'Fetch the archived ffmpeg log for a video render job.',
+        category: 'external',
+        allowBody: false,
+        defaultHeaders: {
+          Authorization: 'Bearer <VIDEO_API_KEY>',
+        },
+        notice: 'Replace job_12345 with the identifier returned from the create job request.',
+      },
     ],
   },
 ];

--- a/apps/web/lib/auth-context.tsx
+++ b/apps/web/lib/auth-context.tsx
@@ -19,6 +19,7 @@ interface AuthContextType {
   loading: boolean;
   signInWithGoogle: () => Promise<void>;
   signOut: () => Promise<void>;
+  authError: string | null;
   isAdmin: boolean;
   isAuthenticated: boolean;
 }
@@ -30,6 +31,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [profile, setProfile] = useState<Profile | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
 
   useEffect(() => {
     // Check active sessions and sets the user
@@ -62,14 +64,39 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const fetchProfile = async (accessToken: string) => {
     try {
-      const response = await fetch('/api/auth/session', {
+      setAuthError(null);
+      const { data: { user } } = await supabase.auth.getUser(accessToken);
+
+      if (user) {
+        const { data: profile, error: profileError } = await supabase
+          .from('profiles')
+          .select('*')
+          .eq('user_id', user.id)
+          .maybeSingle();
+
+        if (profileError) {
+          console.warn('Error fetching profile from Supabase:', profileError);
+        }
+
+        if (profile) {
+          setProfile(profile as Profile);
+          return;
+        }
+      }
+
+      const response = await fetch('/auth/session', {
         headers: {
           'sb-access-token': accessToken,
         },
       });
+      if (!response.ok) {
+        throw new Error(`Session lookup failed (${response.status})`);
+      }
       const data = await response.json();
       setProfile(data.profile);
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error fetching profile';
+      setAuthError(message);
       console.error('Error fetching profile:', error);
     } finally {
       setLoading(false);
@@ -77,13 +104,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const signInWithGoogle = async () => {
+    setAuthError(null);
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${window.location.origin}/admin`,
       },
     });
     if (error) {
+      const message = error.message || 'Error signing in with Google';
+      setAuthError(message);
       console.error('Error signing in with Google:', error);
       throw error;
     }
@@ -110,6 +140,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         loading,
         signInWithGoogle,
         signOut,
+        authError,
         isAdmin,
         isAuthenticated,
       }}

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -1,8 +1,19 @@
-import { supabaseUrl } from './supabase';
+const resolveApiOrigin = () => {
+  const configured = process.env.NEXT_PUBLIC_API_ORIGIN;
+  if (configured) {
+    return configured;
+  }
 
-const defaultApiOrigin = supabaseUrl
-  || (typeof window === 'undefined' ? 'http://localhost:4000' : '');
-export const apiOrigin = defaultApiOrigin;
+  if (typeof window === 'undefined') {
+    return 'http://localhost:4000';
+  }
+
+  // The deployed web app is a static export. Apache routes same-origin API
+  // requests through public/api/index.php, avoiding /api/* static 404s.
+  return window.location.origin;
+};
+
+export const apiOrigin = resolveApiOrigin();
 
 const defaultWsOrigin = process.env.NEXT_PUBLIC_WS_ORIGIN
   ?? (typeof window === 'undefined' ? 'ws://localhost:4001/ws' : '');

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -7,4 +7,7 @@ if (!supabaseUrl || !supabaseAnonKey) {
   console.warn('Supabase environment variables not configured');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const supabaseClientUrl = supabaseUrl || 'http://localhost:54321';
+const supabaseClientAnonKey = supabaseAnonKey || 'local-anon-key';
+
+export const supabase = createClient(supabaseClientUrl, supabaseClientAnonKey);

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,6 +4,7 @@ const isStaticExport = process.env.NEXT_SHOULD_EXPORT === 'true';
 const nextConfig = {
   reactStrictMode: true,
   output: isStaticExport ? 'export' : 'standalone',
+  trailingSlash: isStaticExport,
   images: {
     unoptimized: isStaticExport,
   },

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,7 @@ const isStaticExport = process.env.NEXT_SHOULD_EXPORT === 'true';
 const nextConfig = {
   reactStrictMode: true,
   output: isStaticExport ? 'export' : 'standalone',
+  trailingSlash: isStaticExport,
   images: {
     unoptimized: isStaticExport,
   },

--- a/apps/web/public/.htaccess
+++ b/apps/web/public/.htaccess
@@ -1,0 +1,18 @@
+# Ovida static export + API gateway for DreamHost/Apache.
+#
+# The Next.js web app is deployed as static files, but the admin API test
+# tools intentionally call same-origin API paths such as /api/v1/jobs.
+# Route those requests into the PHP gateway below so Apache does not return
+# a static 404 before the Fastify API service can process ffmpeg jobs.
+
+RewriteEngine On
+
+# Preserve bearer tokens for PHP/FastCGI before proxying to Fastify.
+SetEnvIfNoCase Authorization "(.+)" HTTP_AUTHORIZATION=$1
+
+# Avoid rewriting the gateway implementation to itself.
+RewriteRule ^api/index\.php$ - [L]
+
+# Same-origin API endpoints used by the console and ffmpeg test tool.
+RewriteRule ^api/(.*)$ /api/index.php?path=api/$1 [QSA,L]
+RewriteRule ^v1/(.*)$ /api/index.php?path=v1/$1 [QSA,L]

--- a/apps/web/public/api/index.php
+++ b/apps/web/public/api/index.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Same-origin gateway for the statically exported Ovida console.
+ *
+ * DreamHost serves apps/web/out as static Apache content, while the real API
+ * runs as the Fastify service on localhost:4000. Browser calls to /api/v1/jobs
+ * otherwise hit Apache directly and return 404. This tiny gateway forwards the
+ * original request to the API service so the admin ffmpeg test tool can create,
+ * poll, download, and inspect video jobs from the deployed site.
+ */
+
+declare(strict_types=1);
+
+const DEFAULT_API_ORIGIN = 'http://127.0.0.1:4000';
+
+function gateway_header_value(string $value): bool
+{
+    return !preg_match('/[\r\n]/', $value);
+}
+
+function gateway_request_headers(): array
+{
+    $headers = function_exists('getallheaders') ? getallheaders() : [];
+
+    if (!$headers) {
+        foreach ($_SERVER as $key => $value) {
+            if (substr($key, 0, 5) !== 'HTTP_') {
+                continue;
+            }
+
+            $name = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
+            $headers[$name] = $value;
+        }
+    }
+
+
+    $hasAuthorization = false;
+    foreach ($headers as $name => $_value) {
+        if (strtolower((string) $name) === 'authorization') {
+            $hasAuthorization = true;
+            break;
+        }
+    }
+
+    if (!$hasAuthorization && isset($_SERVER['HTTP_AUTHORIZATION']) && gateway_header_value($_SERVER['HTTP_AUTHORIZATION'])) {
+        $headers['Authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
+    }
+
+    $forwarded = [];
+    $skip = [
+        'host' => true,
+        'content-length' => true,
+        'connection' => true,
+        'accept-encoding' => true,
+    ];
+
+    foreach ($headers as $name => $value) {
+        $lower = strtolower((string) $name);
+        if (isset($skip[$lower]) || !gateway_header_value((string) $value)) {
+            continue;
+        }
+
+        $forwarded[] = $name . ': ' . $value;
+    }
+
+    if (isset($_SERVER['CONTENT_TYPE']) && gateway_header_value($_SERVER['CONTENT_TYPE'])) {
+        $forwarded[] = 'Content-Type: ' . $_SERVER['CONTENT_TYPE'];
+    }
+
+    return $forwarded;
+}
+
+function gateway_path(): string
+{
+    $path = isset($_GET['path']) ? trim((string) $_GET['path'], '/') : '';
+
+    if ($path === '' || strpos($path, '..') !== false || strpos($path, '\\') !== false || preg_match('/[\x00-\x1F\x7F]/', $path)) {
+        http_response_code(400);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo 'Invalid API gateway path.';
+        exit;
+    }
+
+    return $path;
+}
+
+function gateway_query_string(): string
+{
+    $params = [];
+    parse_str($_SERVER['QUERY_STRING'] ?? '', $params);
+    unset($params['path']);
+
+    $query = http_build_query($params);
+    return $query === '' ? '' : '?' . $query;
+}
+
+function gateway_api_origin(): string
+{
+    $configured = getenv('OVIDA_API_PROXY_TARGET') ?: DEFAULT_API_ORIGIN;
+    return rtrim($configured, '/');
+}
+
+$target = gateway_api_origin() . '/' . gateway_path() . gateway_query_string();
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$body = file_get_contents('php://input');
+
+$context = stream_context_create([
+    'http' => [
+        'method' => $method,
+        'header' => implode("\r\n", gateway_request_headers()),
+        'content' => $body === false ? '' : $body,
+        'ignore_errors' => true,
+        'timeout' => 300,
+    ],
+]);
+
+$response = @file_get_contents($target, false, $context);
+
+if ($response === false && empty($http_response_header)) {
+    http_response_code(502);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Ovida API gateway could not reach ' . gateway_api_origin() . '.';
+    exit;
+}
+
+$statusCode = 502;
+foreach ($http_response_header ?? [] as $headerLine) {
+    if (preg_match('#^HTTP/\S+\s+(\d{3})#', $headerLine, $matches)) {
+        $statusCode = (int) $matches[1];
+        continue;
+    }
+
+    $separator = strpos($headerLine, ':');
+    if ($separator === false) {
+        continue;
+    }
+
+    $name = substr($headerLine, 0, $separator);
+    $lower = strtolower($name);
+    if (in_array($lower, ['connection', 'content-length', 'transfer-encoding', 'content-encoding'], true)) {
+        continue;
+    }
+
+    header($headerLine, false);
+}
+
+http_response_code($statusCode);
+echo $response === false ? '' : $response;

--- a/deploy_services.sh
+++ b/deploy_services.sh
@@ -1,114 +1,75 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-echo "🚀 OVIDA Services Deployment Script"
-echo "=================================="
+API_NAME="ovida-api"
+API_DIR="apps/api"
+API_PORT="${PORT:-4000}"
+PID_DIR=".pids"
+LOG_DIR="logs"
 
-# Fix TypeScript build issues first
-echo "🔧 Step 1: Fixing build dependencies..."
+printf '🚀 OVIDA service build/start\n'
+printf '===========================\n'
 
-# Remove problematic lockfile
-rm -f pnpm-lock.yaml
+printf '📦 Installing workspace dependencies...\n'
+pnpm install --frozen-lockfile
 
-# Reinstall dependencies
-echo "📦 Installing dependencies..."
-pnpm install --no-frozen-lockfile
+printf '🏗️ Building web static export...\n'
+pnpm --filter @ovida/web build
 
-# Force install TypeScript dependencies for web
-echo "🔧 Installing TypeScript deps for web app..."
-cd apps/web
-pnpm install --save-dev @types/react @types/react-dom @types/node typescript
-cd ../..
+printf '🏗️ Building API service...\n'
+pnpm --filter @ovida/schemas build
+pnpm --filter @ovida/api build
 
-echo "✅ Dependencies fixed!"
-
-# Build the web application  
-echo "🏗️ Step 2: Building web application..."
-cd apps/web
-pnpm run build
-if [ $? -eq 0 ]; then
-    echo "✅ Web build successful!"
-else
-    echo "❌ Web build failed!"
-    exit 1
+if [ ! -f "${API_DIR}/.env" ]; then
+  cat <<MSG
+❌ Missing ${API_DIR}/.env.
+Create it before starting the VPS API service. Required values include:
+  SUPABASE_URL
+  SUPABASE_ANON_KEY
+  SUPABASE_SERVICE_ROLE_KEY
+  VIDEO_API_KEY
+  APP_ORIGIN=https://ovida.1976.cloud
+  API_ORIGIN=https://ovida.1976.cloud
+  PORT=${API_PORT}
+MSG
+  exit 1
 fi
-cd ../..
 
-# Build the API
-echo "🏗️ Step 3: Building API..."
-cd apps/api
-pnpm install
-pnpm run build
-if [ $? -eq 0 ]; then
-    echo "✅ API build successful!"
+mkdir -p "${PID_DIR}" "${LOG_DIR}"
+
+printf '🚀 Starting Fastify API on 127.0.0.1:%s...\n' "${API_PORT}"
+if command -v pm2 >/dev/null 2>&1; then
+  if pm2 describe "${API_NAME}" >/dev/null 2>&1; then
+    (cd "${API_DIR}" && pm2 restart "${API_NAME}" --update-env)
+  else
+    (cd "${API_DIR}" && pm2 start dist/index.js --name "${API_NAME}" --update-env)
+  fi
+  pm2 save || true
 else
-    echo "❌ API build failed!"
-    exit 1
-fi
-cd ../..
-
-# Deploy services
-echo "🚀 Step 4: Deploying services..."
-
-# Stop existing services
-echo "🔄 Stopping existing services..."
-pkill -f "node mock_api.js" 2>/dev/null || true
-pkill -f "node dist/index.js" 2>/dev/null || true
-lsof -ti:4000 | xargs kill -9 2>/dev/null || true
-lsof -ti:4001 | xargs kill -9 2>/dev/null || true
-
-# Create simple environment file for mock API
-echo "⚙️ Setting up environment..."
-cat > .env << 'EOF'
-NODE_ENV=production
-PORT=4000
-API_ORIGIN=http://localhost:4000
-APP_ORIGIN=https://ovida.1976.cloud
-EOF
-
-# Start mock API service
-echo "🚀 Starting mock API service..."
-nohup node mock_api.js > api.log 2>&1 &
-API_PID=$!
-
-# Start WebSocket service if available
-if [ -d "apps/ws" ]; then
-    echo "🚀 Starting WebSocket service..."
-    cd apps/ws
-    if [ -f "package.json" ]; then
-        pnpm install
-        nohup pnpm start > ../ws.log 2>&1 &
-        WS_PID=$!
-        echo "✅ WebSocket service started with PID: $WS_PID"
+  if [ -f "${PID_DIR}/api.pid" ]; then
+    old_pid="$(cat "${PID_DIR}/api.pid")"
+    if [ -n "${old_pid}" ]; then
+      kill "${old_pid}" 2>/dev/null || true
     fi
-    cd ../..
+  fi
+  (cd "${API_DIR}" && nohup node dist/index.js > "../../${LOG_DIR}/api.log" 2>&1 & echo $! > "../../${PID_DIR}/api.pid")
 fi
 
-echo "✅ Services deployment complete!"
-echo ""
-echo "📊 Service Status:"
-echo "=================="
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  status="$(curl -s -o /tmp/ovida-api-health.txt -w '%{http_code}' "http://127.0.0.1:${API_PORT}/api/v1/jobs/deploy-smoke" || true)"
+  if [ "${status}" = "401" ] || [ "${status}" = "404" ]; then
+    printf '✅ API service is reachable on http://127.0.0.1:%s (HTTP %s).\n' "${API_PORT}" "${status}"
+    printf '✅ Static web output is in apps/web/out.\n'
+    exit 0
+  fi
+  printf 'Waiting for API service (attempt %s, HTTP %s)...\n' "${attempt}" "${status}"
+  sleep 2
+done
 
-# Check API service
-sleep 3
-if ps -p $API_PID > /dev/null 2>&1; then
-    echo "✅ API Service: Running (PID: $API_PID)"
-    echo "🧪 Testing API endpoint..."
-    curl -X POST http://localhost:4000/v1/demos/start -H "Content-Type: application/json" 2>/dev/null | head -c 100
-    echo ""
+printf '❌ API service did not become reachable on http://127.0.0.1:%s.\n' "${API_PORT}"
+if command -v pm2 >/dev/null 2>&1; then
+  pm2 logs "${API_NAME}" --lines 80 --nostream || true
 else
-    echo "❌ API Service: Failed to start"
-    echo "📝 Checking logs:"
-    cat api.log
+  tail -n 80 "${LOG_DIR}/api.log" || true
 fi
-
-echo ""
-echo "🎯 Results:"
-echo "==========="
-echo "✅ Build issues fixed"
-echo "✅ Services deployed"
-echo "🌐 Website: https://ovida.1976.cloud"
-echo "🔗 API: http://localhost:4000"
-echo "📝 Logs: api.log"
-
-echo ""
-echo "🎉 Deployment complete! Demo should now work."
+exit 1

--- a/supabase/migrations/0004_auth_profile_provisioning.sql
+++ b/supabase/migrations/0004_auth_profile_provisioning.sql
@@ -1,0 +1,54 @@
+-- Provision profiles directly from Supabase Auth users.
+-- This keeps Google OAuth sign-ins independent from the app API session endpoint.
+
+create or replace function public.handle_new_auth_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (user_id, display_name, avatar_url)
+  values (
+    new.id,
+    coalesce(
+      new.raw_user_meta_data ->> 'full_name',
+      new.raw_user_meta_data ->> 'name',
+      new.raw_user_meta_data ->> 'display_name',
+      new.email
+    ),
+    coalesce(
+      new.raw_user_meta_data ->> 'avatar_url',
+      new.raw_user_meta_data ->> 'picture'
+    )
+  )
+  on conflict (user_id) do update
+    set display_name = coalesce(public.profiles.display_name, excluded.display_name),
+        avatar_url = coalesce(public.profiles.avatar_url, excluded.avatar_url);
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_auth_user();
+
+insert into public.profiles (user_id, display_name, avatar_url)
+select
+  users.id,
+  coalesce(
+    users.raw_user_meta_data ->> 'full_name',
+    users.raw_user_meta_data ->> 'name',
+    users.raw_user_meta_data ->> 'display_name',
+    users.email
+  ),
+  coalesce(
+    users.raw_user_meta_data ->> 'avatar_url',
+    users.raw_user_meta_data ->> 'picture'
+  )
+from auth.users users
+on conflict (user_id) do nothing;
+
+grant execute on function public.handle_new_auth_user() to service_role;


### PR DESCRIPTION
### Motivation

- Enable building, packaging, uploading, and starting the Fastify API alongside the static Next.js web export during deploy so the console's ffmpeg/video job tooling works in production.
- Provide visibility into ffmpeg job output by exposing archived logs and increasing the create-job body limit to support uploaded assets.
- Improve the admin console with an integrated ffmpeg test tool and better API diagnostics for easier on-site troubleshooting.
- Make the statically exported site behave like a dynamic origin by proxying same-origin /api requests to the local API service on DreamHost.

### Description

- Extended `.github/workflows/deploy.yml` to build the API, package it as `api-deploy/ovida-api-runtime.tar.gz`, upload it via SCP, deploy/unpack on the VPS, install runtime deps, start/restart the service (pm2 or `nohup` fallback), and smoke-test `http://127.0.0.1:4000/api/v1/jobs/deploy-smoke`.
- Added API runtime packaging and optional `API_ENV` handling, plus `API_REMOTE_PATH` support and validation/verification steps in the workflow.
- Added server-side support for logs and larger payloads in the video jobs API by computing a `bodyLimit`, registering `GET /api/v1/jobs/:job_id/log`, and implementing `VideoJobManager.getJobLog` to read archived logs.
- Added unit tests for routes and service logic: `apps/api/src/routes/video.jobs.spec.ts` and `apps/api/src/services/video.jobs.spec.ts` (Vitest), and the built artifacts in `apps/api/dist` were updated accordingly.
- Added an interactive ffmpeg test tool and related styles/UI in the admin console (`/admin/api-tests`) to upload local files as data URLs, submit video jobs, poll status, and fetch job logs; wired into API endpoint definitions and nav links.
- Made static-export-friendly runtime changes: `next.config` trailingSlash option for exports, `apps/web/public/.htaccess` and `apps/web/public/api/index.php` gateway to forward same-origin API calls to the local Fastify service, and updated web runtime config (`lib/config.ts`, `lib/supabase.ts`) to better handle static export and local fallbacks.
- Reworked local VPS helper `deploy_services.sh` to build/start API and perform health checks, and added a Supabase migration `0004_auth_profile_provisioning.sql` to provision profiles from Auth users.
- UX and auth improvements: surfaced auth errors in `AuthProvider`, redirect/behavior updates for static export in callback/session routes, and small admin copy updates and links.

### Testing

- Added Vitest unit tests for API routes and services and ran `pnpm --filter @ovida/api test` (Vitest); tests passed locally for the new route and service specs.
- Performed local builds of the web and API packages with `pnpm --filter @ovida/web build` and `pnpm --filter @ovida/api build`; builds completed successfully in the authoring environment.
- Deploy workflow and `deploy_services.sh` include automated smoke checks against `/api/v1/jobs/deploy-smoke` to verify the API process started, and these checks are executed by the GH Actions workflow during CI deploys.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb55d6f6c83249b52dc0075b0063a)