### PR TITLE
Start Gentle alignment service during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
       BUILD_OUTPUT_DIR: apps/web/out
       API_BUNDLE_PATH: api-deploy/ovida-api-runtime.tar.gz
       API_REMOTE_PATH: ${{ vars.API_REMOTE_PATH != '' && vars.API_REMOTE_PATH || secrets.API_REMOTE_PATH }}
+      GENTLE_PORT: ${{ vars.GENTLE_PORT != '' && vars.GENTLE_PORT || '8765' }}
       REMOTE_PATH: ${{ vars.REMOTE_PATH != '' && vars.REMOTE_PATH || secrets.REMOTE_PATH }}
       NEXT_TELEMETRY_DISABLED: 1
 
@@ -62,6 +63,7 @@ jobs:
           VIDEO_API_KEY: ${{ vars.VIDEO_API_KEY != '' && vars.VIDEO_API_KEY || secrets.VIDEO_API_KEY }}
           APP_ORIGIN: ${{ vars.APP_ORIGIN != '' && vars.APP_ORIGIN || 'https://ovida.1976.cloud' }}
           API_ORIGIN: ${{ vars.API_ORIGIN != '' && vars.API_ORIGIN || 'https://ovida.1976.cloud' }}
+          GENTLE_URL: ${{ vars.GENTLE_URL != '' && vars.GENTLE_URL || 'http://127.0.0.1:8765' }}
         run: |
           set -euo pipefail
           mkdir -p api-deploy
@@ -76,6 +78,9 @@ jobs:
 
           if [ -n "${API_ENV}" ]; then
             printf '%s\n' "${API_ENV}" > api-deploy/.api.env
+            if ! grep -Eq '^GENTLE_URL=' api-deploy/.api.env; then
+              printf 'GENTLE_URL=%s\n' "${GENTLE_URL}" >> api-deploy/.api.env
+            fi
             chmod 600 api-deploy/.api.env
           elif [ -n "${SUPABASE_URL}" ] && [ -n "${SUPABASE_ANON_KEY}" ] && [ -n "${SUPABASE_SERVICE_ROLE_KEY}" ] && [ -n "${VIDEO_API_KEY}" ]; then
             {
@@ -87,6 +92,7 @@ jobs:
               printf 'VIDEO_API_KEY=%s\n' "${VIDEO_API_KEY}"
               printf 'APP_ORIGIN=%s\n' "${APP_ORIGIN}"
               printf 'API_ORIGIN=%s\n' "${API_ORIGIN}"
+              printf 'GENTLE_URL=%s\n' "${GENTLE_URL}"
             } > api-deploy/.api.env
             chmod 600 api-deploy/.api.env
           else
@@ -406,6 +412,58 @@ jobs:
             else
               tail -n 80 "${API_DIR}/logs/api.log" || true
             fi
+            exit 1
+
+      - name: Start Gentle alignment service
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          GENTLE_PORT: ${{ env.GENTLE_PORT }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || '22' }}
+          envs: GENTLE_PORT
+          script: |
+            set -euo pipefail
+
+            GENTLE_PORT="${GENTLE_PORT:-8765}"
+            GENTLE_NAME="ovida-gentle"
+            GENTLE_IMAGE="lowerquality/gentle:latest"
+
+            if ! command -v docker >/dev/null 2>&1; then
+              echo "❌ Docker is required on the deployment host to run the Gentle alignment service."
+              exit 1
+            fi
+
+            if ! docker info >/dev/null 2>&1; then
+              echo "❌ Docker is installed, but the deployment user cannot talk to the Docker daemon."
+              exit 1
+            fi
+
+            if docker ps -a --format '{{.Names}}' | grep -Fxq "${GENTLE_NAME}"; then
+              docker rm -f "${GENTLE_NAME}" >/dev/null
+            fi
+
+            docker pull "${GENTLE_IMAGE}"
+            docker run -d \
+              --name "${GENTLE_NAME}" \
+              --restart unless-stopped \
+              -p "${GENTLE_PORT}:8765" \
+              "${GENTLE_IMAGE}"
+
+            for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+              if python3 -c "import socket; socket.create_connection(('127.0.0.1', int('${GENTLE_PORT}')), 5).close()" >/dev/null 2>&1; then
+                echo "✅ Gentle alignment service is reachable on http://127.0.0.1:${GENTLE_PORT}."
+                exit 0
+              fi
+              echo "Waiting for Gentle alignment service on 127.0.0.1:${GENTLE_PORT} (attempt ${attempt})..."
+              sleep 5
+            done
+
+            echo "❌ Gentle alignment service did not become reachable on http://127.0.0.1:${GENTLE_PORT}."
+            docker logs --tail 100 "${GENTLE_NAME}" || true
             exit 1
 
       - name: Verify remote upload

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -55,12 +55,13 @@ Add one of the following before running the deployment:
    PORT=4000
    APP_ORIGIN=https://ovida.1976.cloud
    API_ORIGIN=https://ovida.1976.cloud
+   GENTLE_URL=http://127.0.0.1:8765
    SUPABASE_URL=...
    SUPABASE_ANON_KEY=...
    SUPABASE_SERVICE_ROLE_KEY=...
    VIDEO_API_KEY=...
    ```
-2. **Separate secrets fallback:** if `API_ENV` is not set, the workflow will synthesize `.env` from `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `VIDEO_API_KEY` repository secrets/variables, plus optional `APP_ORIGIN` and `API_ORIGIN` variables.
+2. **Separate secrets fallback:** if `API_ENV` is not set, the workflow will synthesize `.env` from `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `VIDEO_API_KEY` repository secrets/variables, plus optional `APP_ORIGIN`, `API_ORIGIN`, and `GENTLE_URL` variables.
 3. **Manual VPS fallback:** create the file once on the server at the API deploy path, which defaults to a sibling of the web root named `ovida-api/apps/api/.env`.
 
 If none of these API env sources exists, deployment no longer fails at this step; it skips the Fastify startup and leaves the static PHP ffmpeg fallback available for `/api/v1/jobs`. The fallback normally reads `VIDEO_API_KEY` from protected `.api.env`; if that file is missing on the VPS, it still accepts any non-empty bearer token from the admin test form instead of blocking ffmpeg processing with a configuration error.
@@ -70,8 +71,10 @@ Optional repository variable/secret:
 | Name | Value |
 |------|-------|
 | `API_REMOTE_PATH` | Absolute VPS path for the API runtime bundle. Defaults to a sibling directory named `ovida-api` next to `REMOTE_PATH`. |
+| `GENTLE_PORT` | Public VPS port for the Gentle forced-alignment container. Defaults to `8765`. |
+| `GENTLE_URL` | URL the API should use for Gentle. Defaults to `http://127.0.0.1:8765` when the workflow synthesizes the API env file. |
 
-The workflow injects the `NEXT_PUBLIC_SUPABASE_*` values into the static web build so the browser login bundle does not emit `Supabase environment variables not configured`. It uses PM2 when it is installed; otherwise it starts `node dist/index.js` with `nohup` and writes a PID file. It then checks `http://127.0.0.1:4000/api/v1/jobs/deploy-smoke`, which should return `401` without an API key when the Fastify service is reachable.
+The workflow injects the `NEXT_PUBLIC_SUPABASE_*` values into the static web build so the browser login bundle does not emit `Supabase environment variables not configured`. It uses PM2 when it is installed; otherwise it starts `node dist/index.js` with `nohup` and writes a PID file. It then checks `http://127.0.0.1:4000/api/v1/jobs/deploy-smoke`, which should return `401` without an API key when the Fastify service is reachable. The workflow also starts a Docker-managed `lowerquality/gentle:latest` container named `ovida-gentle`, maps `GENTLE_PORT` to container port `8765`, and fails deployment if the alignment service does not accept local TCP connections.
 
 ### Step 4: Verify Remote Path
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
   - Coqui (local TTS fallback): `COQUI_TTS_URL`, `COQUI_TTS_SPEAKER` (or `COQUI_TTS_VOICE`), `COQUI_TTS_LANGUAGE`, `COQUI_TTS_STYLE_WAV`, and `COQUI_TTS_SPEED`.
   - OpenAI realtime audio: `OPENAI_API_KEY`, `OPENAI_REALTIME_MODEL`, `OPENAI_REALTIME_BASE_URL`, `OPENAI_REALTIME_VOICE`.
 - **Video rendering** – `VIDEO_API_KEY` is required. Storage and limits are controlled with `VIDEO_TMP_DIR`, `VIDEO_OUTPUT_DIR`, `VIDEO_PUBLIC_BASE_URL`, `VIDEO_MAX_INPUT_BYTES`, `VIDEO_MAX_OVERLAY_BYTES`, `VIDEO_MAX_AUDIO_BYTES`, and `VIDEO_CALLBACK_TIMEOUT_MS`. Ensure the directories exist or let the service create them with writable permissions.
+- **Lyric alignment** – `GENTLE_URL` points the API at the Gentle forced-alignment service. Production deployments start `lowerquality/gentle:latest` with Docker on `GENTLE_PORT` (default `8765`) and default the API URL to `http://127.0.0.1:8765`.
 - **Auth providers** – Configure Supabase OAuth (e.g., Google) by setting `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
 - **Additional providers** – If you rely on OpenAI image generation, set `OPENAI_API_KEY` and (optionally) `OPENAI_API_BASE_URL`.
 - **Runtime environment** – `NODE_ENV` defaults to `development`; adjust to `production` in deployed environments alongside hardened CORS settings. `PORT` controls the API server port (defaults to 4000).


### PR DESCRIPTION
### Motivation
- Forced-lyrics alignment (Gentle) must be available to the API, and deploys were not starting or verifying the Gentle service which caused `alignLyrics` connection errors.
- Ensure production deploys provision and verify a local Gentle instance and that the API receives a valid `GENTLE_URL` in its runtime env.

### Description
- Add `GENTLE_PORT` and `GENTLE_URL` variables with sensible defaults to the primary deploy workflow (`.github/workflows/deploy.yml`).
- Ensure generated/provisioned API env files include `GENTLE_URL`, appending it when `API_ENV` is provided or synthesizing it when building `.api.env`.
- Add a deploy step that uses `appleboy/ssh-action` to start/recreate a Docker container `lowerquality/gentle:latest` as `ovida-gentle`, map `GENTLE_PORT`→`8765`, and wait for a local TCP healthcheck, failing the deploy if unreachable.
- Document `GENTLE_URL`/`GENTLE_PORT` usage and behavior in `DEPLOYMENT.md` and `README.md`.

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'`, which succeeded.
- Ran `git diff --check` to validate whitespace/patch issues, which succeeded.
- Ran `pnpm lint`; the lint run failed due to existing/missing ESLint configuration in `packages/sdk` and `packages/schemas` unrelated to these changes (documented as a pre-existing warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33967cb20483249224565f33043980)