### PR TITLE
Add ffmpeg asset upload + PHP upload endpoint and tighten deploy SSH validation

### DIFF
--- a/.github/workflows/deploy-alternative.yml
+++ b/.github/workflows/deploy-alternative.yml
@@ -39,12 +39,49 @@ jobs:
           ls -la ${{ env.WEB_DIR }}/out/
           echo "File count: $(find ${{ env.WEB_DIR }}/out -type f | wc -l)"
 
+      - name: Validate deployment configuration
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          REMOTE_PATH: ${{ vars.REMOTE_PATH }}
+        run: |
+          set -euo pipefail
+          missing=()
+
+          if [ -z "${SSH_HOST}" ]; then
+            missing+=("SSH_HOST")
+          fi
+          if [ -z "${SSH_USER}" ]; then
+            missing+=("SSH_USER")
+          fi
+          if [ -z "${REMOTE_PATH}" ]; then
+            missing+=("REMOTE_PATH")
+          fi
+          if [ -z "${SSH_PASSWORD}" ] && [ -z "${SSH_KEY}" ]; then
+            missing+=("SSH_KEY (recommended) or SSH_PASSWORD")
+          fi
+
+          if [ -n "${SSH_PASSWORD}" ] && [ -z "${SSH_KEY}" ]; then
+            echo "⚠️ SSH_PASSWORD is configured without SSH_KEY. If the host disables password auth, appleboy/ssh-action will fail with: ssh: unable to authenticate, attempted methods [none password]."
+            echo "⚠️ Add the private key as the SSH_KEY secret, or explicitly enable password auth on the host."
+          fi
+
+          if [ ${#missing[@]} -ne 0 ]; then
+            printf '❌ Missing deployment configuration: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          echo "✅ Deployment configuration looks good."
+
       - name: Deploy to server via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT || '22' }}
           script: |
             # Create backup of current deployment
@@ -60,6 +97,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT || '22' }}
           source: "${{ env.WEB_DIR }}/out/*"
           target: ${{ vars.REMOTE_PATH }}
@@ -71,6 +109,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT || '22' }}
           script: |
             # Set proper permissions for web files

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,7 +197,12 @@ jobs:
           fi
 
           if [ -z "${SSH_PASSWORD}" ] && [ -z "${SSH_KEY}" ]; then
-            missing+=("SSH_PASSWORD or SSH_KEY")
+            missing+=("SSH_KEY (recommended) or SSH_PASSWORD")
+          fi
+
+          if [ -n "${SSH_PASSWORD}" ] && [ -z "${SSH_KEY}" ]; then
+            echo "⚠️ SSH_PASSWORD is configured without SSH_KEY. If the host disables password auth, appleboy/ssh-action will fail with: ssh: unable to authenticate, attempted methods [none password]."
+            echo "⚠️ Add the private key as the SSH_KEY secret, or explicitly enable password auth on the host."
           fi
 
           if [ ${#missing[@]} -ne 0 ]; then

--- a/apps/web/app/admin/api-tests/page.tsx
+++ b/apps/web/app/admin/api-tests/page.tsx
@@ -297,6 +297,32 @@ export default function ApiTestToolsPage() {
     }
   };
 
+  const uploadFfmpegAsset = async (file: File, apiKey: string) => {
+    const body = new FormData();
+    body.append('file', file);
+
+    const response = await fetch(buildExternalApiUrl('/api/v1/uploads'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body,
+    });
+    const text = await response.text();
+    if (response.status === 404 || response.status === 405) {
+      return null;
+    }
+
+    let parsed: { url?: string; message?: string } | null = null;
+    try {
+      parsed = text.trim() ? JSON.parse(text) as { url?: string; message?: string } : null;
+    } catch {
+      parsed = null;
+    }
+    if (!response.ok || !parsed?.url) {
+      throw new Error(parsed?.message ?? (text.trim() || `Upload failed: ${response.status} ${response.statusText}`));
+    }
+    return parsed.url;
+  };
+
   const fetchFfmpegLog = async (jobId: string, apiKey: string) => {
     const response = await fetch(buildExternalApiUrl(`/api/v1/jobs/${jobId}/log`), {
       headers: { Authorization: `Bearer ${apiKey}` },
@@ -380,13 +406,54 @@ export default function ApiTestToolsPage() {
       setFfmpegTool((prev) => ({ ...prev, status: 'error', message: 'Enter a VIDEO_API_KEY before running.' }));
       return;
     }
-    if (!ffmpegTool.sourceDataUrl) {
+    if (!ffmpegTool.sourceFile) {
       setFfmpegTool((prev) => ({ ...prev, status: 'error', message: 'Upload a source video before running.' }));
       return;
     }
 
+    setFfmpegTool((prev) => ({
+      ...prev,
+      status: 'loading',
+      message: 'Uploading ffmpeg assets…',
+      result: '',
+      log: '',
+      downloadUrl: undefined,
+    }));
+
+    let sourceUrl: string;
+    let logoUrl: string | undefined;
+    let audioUrl: string | undefined;
+    try {
+      const uploadedSourceUrl = await uploadFfmpegAsset(ffmpegTool.sourceFile, apiKey);
+      const uploadedLogoUrl = ffmpegTool.logoFile ? await uploadFfmpegAsset(ffmpegTool.logoFile, apiKey) : undefined;
+      const uploadedAudioUrl = ffmpegTool.audioFile ? await uploadFfmpegAsset(ffmpegTool.audioFile, apiKey) : undefined;
+      const uploadRouteUnsupported = uploadedSourceUrl === null || uploadedLogoUrl === null || uploadedAudioUrl === null;
+
+      sourceUrl = uploadedSourceUrl ?? ffmpegTool.sourceDataUrl ?? '';
+      logoUrl = uploadedLogoUrl ?? ffmpegTool.logoDataUrl;
+      audioUrl = uploadedAudioUrl ?? ffmpegTool.audioDataUrl;
+
+      if (!sourceUrl) {
+        throw new Error('Source upload failed and no local data URL fallback is available.');
+      }
+
+      if (uploadRouteUnsupported) {
+        setFfmpegTool((prev) => ({
+          ...prev,
+          message: 'Upload endpoint unavailable; submitting direct API request with data URL assets…',
+        }));
+      }
+    } catch (error) {
+      setFfmpegTool((prev) => ({
+        ...prev,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to upload ffmpeg assets.',
+      }));
+      return;
+    }
+
     const payload = {
-      source_url: ffmpegTool.sourceDataUrl,
+      source_url: sourceUrl,
       overlays: [
         {
           type: 'text',
@@ -400,11 +467,11 @@ export default function ApiTestToolsPage() {
           end: 4,
           shadow: true,
         },
-        ...(ffmpegTool.logoDataUrl
+        ...(logoUrl
           ? [
               {
                 type: 'logo',
-                asset_url: ffmpegTool.logoDataUrl,
+                asset_url: logoUrl,
                 x: 'main_w-overlay_w-32',
                 y: 'main_h-overlay_h-32',
                 start: 0,
@@ -417,14 +484,14 @@ export default function ApiTestToolsPage() {
           : []),
       ],
       output_format: ffmpegTool.outputFormat,
-      ...(ffmpegTool.audioDataUrl ? { audio_url: ffmpegTool.audioDataUrl } : {}),
+      ...(audioUrl ? { audio_url: audioUrl } : {}),
     };
 
     setFfmpegTool((prev) => ({
       ...prev,
       status: 'loading',
       message: 'Submitting ffmpeg render job…',
-      result: JSON.stringify(payload, (key, value) => (String(value).startsWith('data:') ? '[uploaded data URL]' : value), 2),
+      result: JSON.stringify(payload, null, 2),
       log: '',
       downloadUrl: undefined,
     }));
@@ -518,7 +585,7 @@ export default function ApiTestToolsPage() {
             <p className={styles.eyebrow}>ffmpeg workflow</p>
             <h2>Upload Assets & Run Video Job</h2>
             <p>
-              Convert local test assets to data URLs, submit them to the ffmpeg API, poll for results,
+              Upload local test assets to real URLs, submit them to the ffmpeg API, poll for results,
               and fetch the archived render log without leaving the admin test page.
             </p>
           </div>

--- a/apps/web/app/admin/api-tests/page.tsx
+++ b/apps/web/app/admin/api-tests/page.tsx
@@ -79,6 +79,15 @@ const formatFileLabel = (file?: File | null) => {
   return `${file.name} · ${sizeMb.toFixed(sizeMb >= 10 ? 1 : 2)} MB`;
 };
 
+
+const maskDataUrlPayload = (_key: string, value: unknown) => {
+  if (typeof value === 'string' && value.startsWith('data:')) {
+    const [metadata] = value.split(',', 1);
+    return `${metadata || 'data:'},[uploaded data URL]`;
+  }
+  return value;
+};
+
 type FfmpegToolStatus = 'idle' | 'loading' | 'success' | 'error';
 
 type FfmpegToolState = {
@@ -491,7 +500,7 @@ export default function ApiTestToolsPage() {
       ...prev,
       status: 'loading',
       message: 'Submitting ffmpeg render job…',
-      result: JSON.stringify(payload, null, 2),
+      result: JSON.stringify(payload, maskDataUrlPayload, 2),
       log: '',
       downloadUrl: undefined,
     }));

--- a/apps/web/public/api/video-fallback.php
+++ b/apps/web/public/api/video-fallback.php
@@ -100,6 +100,11 @@ function video_fallback_jobs_root(): string
     return video_fallback_output_root() . '/php-jobs';
 }
 
+function video_fallback_upload_root(): string
+{
+    return video_fallback_output_root() . '/uploads';
+}
+
 function video_fallback_public_origin(): string
 {
     $configured = video_fallback_setting('APP_ORIGIN') ?: video_fallback_setting('API_ORIGIN');
@@ -186,8 +191,13 @@ function video_fallback_write_job(array $job): void
 
 function video_fallback_decode_asset(string $dataUrl, string $destination, array $allowedMimes): void
 {
+    if (preg_match('#^https?://#i', $dataUrl)) {
+        video_fallback_download_asset($dataUrl, $destination, $allowedMimes);
+        return;
+    }
+
     if (!preg_match('#^data:([^;,]+)(;base64)?,(.*)$#s', $dataUrl, $matches)) {
-        throw new RuntimeException('Only data URL uploads are supported by the PHP fallback.');
+        throw new RuntimeException('Asset URL must be an http(s) URL or a data URL upload.');
     }
 
     $mime = strtolower($matches[1]);
@@ -201,6 +211,96 @@ function video_fallback_decode_asset(string $dataUrl, string $destination, array
     }
 
     file_put_contents($destination, $raw, LOCK_EX);
+}
+
+
+function video_fallback_download_asset(string $url, string $destination, array $allowedMimes): void
+{
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'ignore_errors' => true,
+            'timeout' => 300,
+        ],
+    ]);
+    $data = @file_get_contents($url, false, $context);
+    if ($data === false || $data === '') {
+        throw new RuntimeException('Unable to download asset URL.');
+    }
+
+    $contentType = null;
+    foreach ($http_response_header ?? [] as $headerLine) {
+        if (preg_match('#^HTTP/\S+\s+(\d{3})#', $headerLine, $matches) && (int) $matches[1] >= 400) {
+            throw new RuntimeException('Asset URL returned HTTP ' . $matches[1] . '.');
+        }
+        if (stripos($headerLine, 'Content-Type:') === 0) {
+            $contentType = strtolower(trim(explode(':', $headerLine, 2)[1]));
+            $contentType = trim(explode(';', $contentType, 2)[0]);
+        }
+    }
+
+    if ($allowedMimes && $contentType && !in_array($contentType, $allowedMimes, true)) {
+        throw new RuntimeException('Unsupported asset URL type: ' . $contentType);
+    }
+
+    file_put_contents($destination, $data, LOCK_EX);
+}
+
+function video_fallback_upload_asset(): void
+{
+    if (!video_fallback_require_auth()) {
+        return;
+    }
+
+    $upload = $_FILES['file'] ?? null;
+    if (!is_array($upload) || ($upload['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+        video_fallback_send_json(400, ['message' => 'Upload a file field named file.']);
+        return;
+    }
+
+    $tmpName = (string) ($upload['tmp_name'] ?? '');
+    if ($tmpName === '' || !is_uploaded_file($tmpName)) {
+        video_fallback_send_json(400, ['message' => 'Uploaded file is not available.']);
+        return;
+    }
+
+    $mime = strtolower((string) (mime_content_type($tmpName) ?: ($upload['type'] ?? 'application/octet-stream')));
+    $extensions = [
+        'video/mp4' => 'mp4',
+        'video/quicktime' => 'mov',
+        'video/x-matroska' => 'mkv',
+        'video/webm' => 'webm',
+        'image/png' => 'png',
+        'image/jpeg' => 'jpg',
+        'image/webp' => 'webp',
+        'audio/mpeg' => 'mp3',
+        'audio/mp4' => 'm4a',
+        'audio/wav' => 'wav',
+        'audio/x-wav' => 'wav',
+        'audio/aac' => 'aac',
+    ];
+    if (!isset($extensions[$mime])) {
+        video_fallback_send_json(400, ['message' => 'Unsupported upload type: ' . $mime]);
+        return;
+    }
+
+    $root = video_fallback_upload_root();
+    if (!is_dir($root)) {
+        mkdir($root, 0775, true);
+    }
+
+    $filename = bin2hex(random_bytes(16)) . '.' . $extensions[$mime];
+    $destination = $root . '/' . $filename;
+    if (!move_uploaded_file($tmpName, $destination)) {
+        video_fallback_send_json(500, ['message' => 'Unable to store uploaded file.']);
+        return;
+    }
+
+    video_fallback_send_json(201, [
+        'url' => video_fallback_public_origin() . '/api/v1/uploads/' . rawurlencode($filename),
+        'content_type' => $mime,
+        'size' => filesize($destination),
+    ]);
 }
 
 function video_fallback_find_logo_overlay(array $payload): ?array
@@ -361,9 +461,39 @@ function video_fallback_download(string $jobId): void
     readfile($path);
 }
 
+
+function video_fallback_uploaded_asset(string $filename): void
+{
+    if (!preg_match('/^[a-f0-9]{32}\.[A-Za-z0-9]+$/', $filename)) {
+        video_fallback_send_json(404, ['message' => 'Upload not found']);
+        return;
+    }
+
+    $path = video_fallback_upload_root() . '/' . $filename;
+    if (!is_readable($path)) {
+        video_fallback_send_json(404, ['message' => 'Upload not found']);
+        return;
+    }
+
+    $mime = mime_content_type($path) ?: 'application/octet-stream';
+    header('Content-Type: ' . $mime);
+    header('Content-Length: ' . filesize($path));
+    readfile($path);
+}
+
 function video_fallback_handle(string $path, string $method, string $body): bool
 {
     $path = trim($path, '/');
+    if ($path === 'api/v1/uploads' && strtoupper($method) === 'POST') {
+        video_fallback_upload_asset();
+        return true;
+    }
+
+    if (preg_match('#^api/v1/uploads/([^/]+)$#', $path, $matches) && strtoupper($method) === 'GET') {
+        video_fallback_uploaded_asset(rawurldecode($matches[1]));
+        return true;
+    }
+
     if ($path === 'api/v1/jobs' && strtoupper($method) === 'POST') {
         video_fallback_create_job($body);
         return true;


### PR DESCRIPTION
### Motivation

- Enable uploading local test assets to real URLs so the ffmpeg admin tool can submit remote asset URLs to the video API instead of only embedding data URLs.  
- Provide a simple server-side upload endpoint for storing assets when using the PHP fallback, and allow the fallback to download remote asset URLs.  
- Improve GitHub Actions deploy workflows by validating required SSH/deploy configuration and prefer `SSH_KEY` usage with clearer warnings.

### Description

- Frontend: added `uploadFfmpegAsset` and updated `runFfmpegTool` in `apps/web/app/admin/api-tests/page.tsx` to upload `source`, `logo`, and `audio` files to `/api/v1/uploads`, fall back to data URLs when the upload route is unavailable, and update payload construction and UI copy accordingly.  
- Backend (PHP fallback): added `video_fallback_upload_root`, `video_fallback_download_asset`, `video_fallback_upload_asset`, and `video_fallback_uploaded_asset` handlers in `apps/web/public/api/video-fallback.php` to accept `POST /api/v1/uploads`, serve uploaded files at `GET /api/v1/uploads/:filename`, allow downloading http(s) asset URLs, and adapt decoding error messages.  
- Workflows: updated `.github/workflows/deploy.yml` and `.github/workflows/deploy-alternative.yml` to validate presence of `SSH_HOST`, `SSH_USER`, `REMOTE_PATH`, and either `SSH_KEY` or `SSH_PASSWORD`, emit warnings when only `SSH_PASSWORD` is set, and pass `SSH_KEY` into `appleboy/ssh-action` and `appleboy/scp-action` calls.

### Testing

- Ran the frontend build step with `pnpm --filter @ovida/web build` as part of CI and the build completed successfully.  
- Verified `ls` and file count inspection step in the workflow to ensure `WEB_DIR/out` exists during the deploy job.  
- Exercised the new PHP upload handler by invoking the upload route during dev verification and confirmed it returns `201` with a reachable `url` for stored files.  
- No new automated unit tests were added in this change; existing CI build steps passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3415ab1c948324a4a1e3444895895f)